### PR TITLE
feat(ui): add keyboard shortcuts for SRT editor

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -246,6 +246,7 @@
     "shortcut_suggest": "AI suggestion",
     "shortcut_nudge_back": "Nudge time back",
     "shortcut_nudge_forward": "Nudge time forward",
+    "shortcut_tab_nav": "Next / previous segment",
     "shortcut_help": "Show shortcuts"
   },
   "status": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -246,6 +246,7 @@
     "shortcut_suggest": "AI提案",
     "shortcut_nudge_back": "時間を戻す",
     "shortcut_nudge_forward": "時間を進める",
+    "shortcut_tab_nav": "次 / 前のセグメント",
     "shortcut_help": "ショートカット表示"
   },
   "status": {

--- a/src/static/js/srt-editor/keyboard-shortcuts.js
+++ b/src/static/js/srt-editor/keyboard-shortcuts.js
@@ -22,6 +22,7 @@ export function createKeyboardShortcuts(i18n) {
         getShortcutList() {
             return [
                 { keys: '\u2191 / \u2193', desc: i18n.navUp + ' / ' + i18n.navDown },
+                { keys: 'Tab / Shift+Tab', desc: i18n.tabNav },
                 { keys: 'Enter', desc: i18n.expand },
                 { keys: 'Escape', desc: i18n.collapse },
                 { keys: 'Space', desc: i18n.playSegment },
@@ -35,13 +36,33 @@ export function createKeyboardShortcuts(i18n) {
             ];
         },
 
+        _isEditableTarget(target) {
+            if (!target) return false;
+            if (target.isContentEditable) return true;
+            // Tag-based check covers form fields and interactive controls
+            // that natively respond to Space/Enter (buttons, links, selects).
+            switch (target.tagName) {
+                case 'TEXTAREA':
+                case 'INPUT':
+                case 'SELECT':
+                case 'BUTTON':
+                case 'A':
+                    return true;
+                default:
+                    return false;
+            }
+        },
+
         _handleKeydown(e) {
-            var inInput = (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT');
+            var inInput = this._isEditableTarget(e.target);
             var ctrl = e.ctrlKey || e.metaKey;
+            // Normalize letter keys: e.key is 'S' when Caps Lock is on or
+            // Shift is held, so we lowercase before matching.
+            var key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
 
             // Ctrl combos — always active
             if (ctrl) {
-                switch (e.key) {
+                switch (key) {
                     case 's':
                         e.preventDefault();
                         this.saveSegments();
@@ -66,7 +87,7 @@ export function createKeyboardShortcuts(i18n) {
             }
 
             // Escape — always active
-            if (e.key === 'Escape') {
+            if (key === 'Escape') {
                 e.preventDefault();
                 this._helpVisible = false;
                 this.activeSegmentIdx = null;
@@ -75,10 +96,22 @@ export function createKeyboardShortcuts(i18n) {
                 return;
             }
 
-            // Skip remaining shortcuts when in text fields
+            // When the help modal is open, only Escape and ? are handled
+            // (Escape is above; ? toggles the modal). Block all other keys
+            // so they don't mutate editor state behind the modal.
+            if (this._helpVisible) {
+                if (key === '?') {
+                    e.preventDefault();
+                    this._helpVisible = false;
+                }
+                return;
+            }
+
+            // Skip remaining shortcuts when focus is on an editable/interactive
+            // element so we don't hijack native keyboard behavior.
             if (inInput) return;
 
-            switch (e.key) {
+            switch (key) {
                 case 'ArrowUp':
                     e.preventDefault();
                     this._navigateSegment(-1);
@@ -117,6 +150,7 @@ export function createKeyboardShortcuts(i18n) {
                     }
                     return;
                 case '?':
+                    e.preventDefault();
                     this._helpVisible = !this._helpVisible;
                     return;
             }

--- a/src/templates/srt_editor.html
+++ b/src/templates/srt_editor.html
@@ -24,19 +24,20 @@ var i18n = {
     mergeConsecutiveOnly: {{ t("srt_editor.merge_consecutive_only")|tojson }},
 };
 var shortcutI18n = {
-    navUp: '{{ t("srt_editor.shortcut_nav_up") }}',
-    navDown: '{{ t("srt_editor.shortcut_nav_down") }}',
-    expand: '{{ t("srt_editor.shortcut_expand") }}',
-    collapse: '{{ t("srt_editor.shortcut_collapse") }}',
-    playSegment: '{{ t("srt_editor.shortcut_play_segment") }}',
-    playGlobal: '{{ t("srt_editor.shortcut_play_global") }}',
-    save: '{{ t("srt_editor.shortcut_save") }}',
-    merge: '{{ t("srt_editor.shortcut_merge") }}',
-    deleteKey: '{{ t("srt_editor.shortcut_delete") }}',
-    suggest: '{{ t("srt_editor.shortcut_suggest") }}',
-    nudgeBack: '{{ t("srt_editor.shortcut_nudge_back") }}',
-    nudgeForward: '{{ t("srt_editor.shortcut_nudge_forward") }}',
-    help: '{{ t("srt_editor.shortcut_help") }}',
+    navUp: {{ t("srt_editor.shortcut_nav_up")|tojson }},
+    navDown: {{ t("srt_editor.shortcut_nav_down")|tojson }},
+    expand: {{ t("srt_editor.shortcut_expand")|tojson }},
+    collapse: {{ t("srt_editor.shortcut_collapse")|tojson }},
+    playSegment: {{ t("srt_editor.shortcut_play_segment")|tojson }},
+    playGlobal: {{ t("srt_editor.shortcut_play_global")|tojson }},
+    save: {{ t("srt_editor.shortcut_save")|tojson }},
+    merge: {{ t("srt_editor.shortcut_merge")|tojson }},
+    deleteKey: {{ t("srt_editor.shortcut_delete")|tojson }},
+    suggest: {{ t("srt_editor.shortcut_suggest")|tojson }},
+    nudgeBack: {{ t("srt_editor.shortcut_nudge_back")|tojson }},
+    nudgeForward: {{ t("srt_editor.shortcut_nudge_forward")|tojson }},
+    tabNav: {{ t("srt_editor.shortcut_tab_nav")|tojson }},
+    help: {{ t("srt_editor.shortcut_help")|tojson }},
 };
 
 window.srtEditor = function () {
@@ -349,11 +350,14 @@ window.srtEditor = function () {
 
     <!-- Keyboard shortcuts help modal -->
     <div x-show="_helpVisible" x-transition @click.self="_helpVisible = false" @keydown.escape.window="_helpVisible = false"
-         class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" x-cloak>
+         class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+         role="dialog" aria-modal="true" aria-labelledby="srt-shortcuts-title" x-cloak>
         <div class="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6" @click.stop>
             <div class="flex items-center justify-between mb-4">
-                <h3 class="text-lg font-semibold text-gray-900">{{ t('srt_editor.shortcuts_title') }}</h3>
-                <button @click="_helpVisible = false" class="text-gray-400 hover:text-gray-600 text-xl">&times;</button>
+                <h3 id="srt-shortcuts-title" class="text-lg font-semibold text-gray-900">{{ t('srt_editor.shortcuts_title') }}</h3>
+                <button @click="_helpVisible = false"
+                        class="text-gray-400 hover:text-gray-600 text-xl"
+                        aria-label="{{ t('srt_editor.cancel') }}">&times;</button>
             </div>
             <div class="space-y-1.5">
                 <template x-for="s in getShortcutList()" :key="s.keys">
@@ -370,6 +374,7 @@ window.srtEditor = function () {
     <div class="fixed bottom-6 right-6 z-40" x-show="!_helpVisible">
         <button @click="_helpVisible = true"
                 class="w-8 h-8 bg-gray-200 hover:bg-gray-300 text-gray-600 rounded-full shadow text-sm font-bold"
+                aria-label="{{ t('srt_editor.shortcuts_title') }}"
                 title="{{ t('srt_editor.shortcuts_title') }}">?</button>
     </div>
 </div>


### PR DESCRIPTION
## Summary
Re-opening #43 (auto-closed when its base branch `feat/25-srt-editor-modules` was deleted on merge of #42). All review feedback from the original PR has been addressed.

- 12 keyboard shortcuts for the SRT editor (`?` opens help modal)
- Scope-aware: shortcuts suppressed in textarea/input/button/select/contenteditable except `Ctrl+S/M/D/Enter` and `Escape`
- Cross-platform: `Ctrl` on Windows/Linux, `Cmd` on macOS
- Modal-open guard: only `Escape` and `?` work while help modal is visible
- Case-insensitive letter matching (works with Caps Lock / Shift)
- ARIA: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `aria-label` on icon buttons
- i18n: en + ja translations for all shortcut descriptions

Verified end-to-end with Playwright (9/9 checks pass): editor loads, Tab navigation, modal toggle, keys blocked when modal open, case-insensitive Ctrl+S, ARIA attributes present, no HTML entity escaping in i18n strings.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)