### PR TITLE
fix(ui): guard meta editor against null audio_duration

### DIFF
--- a/src/templates/meta_editor.html
+++ b/src/templates/meta_editor.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="max-w-3xl mx-auto" x-data="metaEditor()" x-init="loadSavedContext(); loadModels()">
     <h1 class="text-2xl font-bold text-gray-900 mb-2">{{ t('meta.heading') }}</h1>
-    <p class="text-sm text-gray-500 mb-6">{{ job.filename }} ({{ "%.1f"|format(job.audio_duration) }}s)</p>
+    <p class="text-sm text-gray-500 mb-6">{{ job.filename }}{% if job.audio_duration %} ({{ "%.1f"|format(job.audio_duration) }}s){% endif %}</p>
 
     <!-- Step 1: Context & Prompt Editor -->
     <div x-show="step === 'edit'" class="space-y-4">


### PR DESCRIPTION
## Summary
- Meta editor page crashes with `TypeError: must be real number, not NoneType` when `job.audio_duration` is `None`
- Wraps the duration display in `{% if job.audio_duration %}` so the page renders cleanly for jobs without a recorded duration

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] Page renders HTTP 200 for an affected job (was 500 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)