### PR TITLE
feat(ui): add dark mode support with class-based toggle

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,10 @@
     "upload": "Upload",
     "history": "History",
     "costs": "Costs",
-    "settings": "Settings"
+    "settings": "Settings",
+    "theme_toggle": "Toggle theme",
+    "theme_light": "Switch to light mode",
+    "theme_dark": "Switch to dark mode"
   },
   "upload": {
     "title": "Upload",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -3,7 +3,10 @@
     "upload": "\u30a2\u30c3\u30d7\u30ed\u30fc\u30c9",
     "history": "履歴",
     "costs": "\u30b3\u30b9\u30c8",
-    "settings": "\u8a2d\u5b9a"
+    "settings": "\u8a2d\u5b9a",
+    "theme_toggle": "テーマ切替",
+    "theme_light": "ライトモードに切替",
+    "theme_dark": "ダークモードに切替"
   },
   "upload": {
     "title": "\u30a2\u30c3\u30d7\u30ed\u30fc\u30c9",

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,10 +1,32 @@
 <!DOCTYPE html>
-<html lang="{{ lang }}" class="h-full bg-gray-50">
+<html lang="{{ lang }}" class="h-full bg-gray-50 dark:bg-gray-900">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}VoiceSRT{% endblock %}</title>
+    <script>
+        // Sync theme to <html> before paint to prevent flash of light content
+        (function() {
+            var stored = localStorage.getItem('theme');
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (stored === 'dark' || (stored === null && prefersDark)) {
+                document.documentElement.classList.add('dark');
+            }
+        })();
+        function toggleTheme() {
+            var isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        }
+        // Set both before AND after the CDN script: the Play CDN replaces
+        // window.tailwind on load in some builds, so the post-load assignment
+        // is the reliable one — but the pre-load assignment avoids a brief
+        // moment where dark: variants compile under prefers-color-scheme.
+        window.tailwind = { config: { darkMode: 'class' } };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script src="/static/js/model-loader.js"></script>
     <script src="/static/js/job-status.js"></script>
@@ -15,7 +37,7 @@
     </style>
     {% block head %}{% endblock %}
 </head>
-<body class="h-full" hx-headers='{"X-Requested-With": "XMLHttpRequest"}'>
+<body class="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100" hx-headers='{"X-Requested-With": "XMLHttpRequest"}'>
     <div class="min-h-full">
         <nav class="bg-gray-800">
             <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -42,8 +64,19 @@
                         </div>
                     </div>
                     <div class="flex items-center space-x-2 text-sm">
+                        <button onclick="toggleTheme()"
+                                class="text-gray-300 hover:text-white p-2 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+                                aria-label="{{ t('nav.theme_toggle') }}"
+                                title="{{ t('nav.theme_toggle') }}">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 hidden dark:inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707m12.728 0l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                            </svg>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 inline dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                            </svg>
+                        </button>
                         <a href="/lang/en" class="text-gray-300 hover:text-white px-2 py-1 rounded {% if lang == 'en' %}bg-gray-700 text-white{% endif %}">EN</a>
-                        <span class="text-gray-500">|</span>
+                        <span class="text-gray-400">|</span>
                         <a href="/lang/ja" class="text-gray-300 hover:text-white px-2 py-1 rounded {% if lang == 'ja' %}bg-gray-700 text-white{% endif %}">JA</a>
                     </div>
                 </div>
@@ -68,9 +101,9 @@
                  x-transition:leave-start="opacity-100"
                  x-transition:leave-end="opacity-0"
                  :class="{
-                     'bg-red-50 border-red-300 text-red-800': toast.type === 'error',
-                     'bg-yellow-50 border-yellow-300 text-yellow-800': toast.type === 'warning',
-                     'bg-green-50 border-green-300 text-green-800': toast.type === 'success'
+                     'bg-red-50 dark:bg-red-900/40 border-red-300 dark:border-red-700 text-red-800 dark:text-red-200': toast.type === 'error',
+                     'bg-yellow-50 dark:bg-yellow-900/40 border-yellow-300 dark:border-yellow-700 text-yellow-800 dark:text-yellow-200': toast.type === 'warning',
+                     'bg-green-50 dark:bg-green-900/40 border-green-300 dark:border-green-700 text-green-800 dark:text-green-200': toast.type === 'success'
                  }"
                  class="border rounded-lg shadow-lg p-4 flex items-start gap-3"
                  role="alert">

--- a/src/templates/costs.html
+++ b/src/templates/costs.html
@@ -1,38 +1,38 @@
 {% extends "base.html" %}
 {% block title %}{{ t('costs.title') }} - VoiceSRT{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold text-gray-900 mb-6">{{ t('costs.heading') }}</h1>
+<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{{ t('costs.heading') }}</h1>
 
 <div x-data="costDashboard()" x-init="loadCosts()">
     <!-- Summary Cards -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        <div class="bg-white shadow rounded-lg p-6">
-            <p class="text-sm text-gray-500">{{ t('costs.total_cost') }}</p>
-            <p class="text-3xl font-bold text-gray-900" x-text="'$' + data.total.toFixed(4)">$0.00</p>
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <p class="text-sm text-gray-500 dark:text-gray-400">{{ t('costs.total_cost') }}</p>
+            <p class="text-3xl font-bold text-gray-900 dark:text-gray-100" x-text="'$' + data.total.toFixed(4)">$0.00</p>
         </div>
         <template x-for="(cost, provider) in data.by_provider" :key="provider">
-            <div class="bg-white shadow rounded-lg p-6">
-                <p class="text-sm text-gray-500" x-text="provider"></p>
-                <p class="text-2xl font-bold text-gray-900" x-text="'$' + cost.toFixed(4)"></p>
+            <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+                <p class="text-sm text-gray-500 dark:text-gray-400" x-text="provider"></p>
+                <p class="text-2xl font-bold text-gray-900 dark:text-gray-100" x-text="'$' + cost.toFixed(4)"></p>
             </div>
         </template>
     </div>
 
     <!-- Monthly Breakdown -->
-    <div class="bg-white shadow rounded-lg p-6 mb-6" x-show="data.by_month.length > 0">
-        <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('costs.monthly_costs') }}</h2>
-        <table class="min-w-full divide-y divide-gray-200">
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6" x-show="data.by_month.length > 0">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('costs.monthly_costs') }}</h2>
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead>
                 <tr>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_month') }}</th>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_cost') }}</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_month') }}</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_cost') }}</th>
                 </tr>
             </thead>
-            <tbody class="divide-y divide-gray-200">
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                 <template x-for="item in data.by_month" :key="item.month">
                     <tr>
-                        <td class="px-4 py-2 text-sm text-gray-900" x-text="item.month"></td>
-                        <td class="px-4 py-2 text-sm text-gray-900" x-text="'$' + item.cost.toFixed(4)"></td>
+                        <td class="px-4 py-2 text-sm text-gray-900 dark:text-gray-100" x-text="item.month"></td>
+                        <td class="px-4 py-2 text-sm text-gray-900 dark:text-gray-100" x-text="'$' + item.cost.toFixed(4)"></td>
                     </tr>
                 </template>
             </tbody>
@@ -40,21 +40,21 @@
     </div>
 
     <!-- Recent Logs -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('costs.recent_api_calls') }}</h2>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('costs.recent_api_calls') }}</h2>
         <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                 <thead>
                     <tr>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_provider') }}</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_model') }}</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_operation') }}</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_duration') }}</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_cost') }}</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">{{ t('costs.col_date') }}</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_provider') }}</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_model') }}</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_operation') }}</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_duration') }}</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_cost') }}</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('costs.col_date') }}</th>
                     </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-200">
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                     <template x-for="log in data.recent" :key="log.created_at">
                         <tr>
                             <td class="px-4 py-2 text-sm" x-text="log.provider"></td>
@@ -62,13 +62,13 @@
                             <td class="px-4 py-2 text-sm" x-text="log.operation"></td>
                             <td class="px-4 py-2 text-sm" x-text="log.audio_duration ? log.audio_duration.toFixed(1) + 's' : '-'"></td>
                             <td class="px-4 py-2 text-sm font-medium" x-text="'$' + log.estimated_cost.toFixed(4)"></td>
-                            <td class="px-4 py-2 text-sm text-gray-500" x-text="log.created_at?.slice(0, 16).replace('T', ' ')"></td>
+                            <td class="px-4 py-2 text-sm text-gray-500 dark:text-gray-400" x-text="log.created_at?.slice(0, 16).replace('T', ' ')"></td>
                         </tr>
                     </template>
                 </tbody>
             </table>
         </div>
-        <p x-show="data.recent.length === 0" class="text-sm text-gray-500 text-center py-4">{{ t('costs.no_api_calls') }}</p>
+        <p x-show="data.recent.length === 0" class="text-sm text-gray-500 dark:text-gray-400 text-center py-4">{{ t('costs.no_api_calls') }}</p>
     </div>
 </div>
 

--- a/src/templates/history.html
+++ b/src/templates/history.html
@@ -1,28 +1,28 @@
 {% extends "base.html" %}
 {% block title %}{{ t('history.title') }} - VoiceSRT{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold text-gray-900 mb-6">{{ t('history.heading') }}</h1>
+<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{{ t('history.heading') }}</h1>
 
-<div class="bg-white shadow rounded-lg overflow-x-auto">
-    <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+<div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-900">
             <tr>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ t('history.col_file') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ t('history.col_provider') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ t('history.col_mode') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ t('history.col_duration') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ t('history.col_status') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">{{ t('history.col_created') }}</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('history.col_file') }}</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('history.col_provider') }}</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('history.col_mode') }}</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('history.col_duration') }}</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('history.col_status') }}</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{{ t('history.col_created') }}</th>
             </tr>
         </thead>
         {% for job in jobs %}
-        <tbody class="border-b border-gray-200" id="job-{{ job.id }}">
+        <tbody class="border-b border-gray-200 dark:border-gray-700" id="job-{{ job.id }}">
             <!-- Row 1: Info -->
             <tr>
-                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-900 font-medium">{{ job.filename }}</td>
-                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500">{{ job.provider }}</td>
-                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500">{{ job.refine_mode or '-' }}</td>
-                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500">
+                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 font-medium">{{ job.filename }}</td>
+                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ job.provider }}</td>
+                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ job.refine_mode or '-' }}</td>
+                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {% if job.audio_duration %}{{ "%.1f"|format(job.audio_duration) }}s{% else %}-{% endif %}
                 </td>
                 <td class="px-6 pt-4 pb-2 max-w-[200px]">
@@ -31,7 +31,7 @@
                         {% include "partials/job_status.html" %}
                     </span>
                 </td>
-                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500">
+                <td class="px-6 pt-4 pb-2 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {{ job.created_at.strftime('%Y-%m-%d %H:%M') if job.created_at else '-' }}
                 </td>
             </tr>
@@ -42,38 +42,38 @@
                         <!-- SRT group -->
                         {% if job.srt_path %}
                         <div class="flex items-center gap-1">
-                            <span class="text-xs text-gray-400 mr-1">SRT</span>
+                            <span class="text-xs text-gray-400 dark:text-gray-500 mr-1">SRT</span>
                             <a href="/srt/{{ job.id }}"
-                               class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100">{{ t('history.srt_editor') }}</a>
+                               class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-200 hover:bg-blue-100">{{ t('history.srt_editor') }}</a>
                             <a href="/api/jobs/{{ job.id }}/download"
-                               class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100">SRT</a>
+                               class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-200 hover:bg-blue-100">SRT</a>
                             <a href="/api/jobs/{{ job.id }}/download-vtt"
-                               class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100">VTT</a>
+                               class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-200 hover:bg-blue-100">VTT</a>
                         </div>
                         {% endif %}
 
                         <!-- YouTube group -->
                         {% if job.srt_path and job.status in ('completed', 'failed') %}
                         <div class="flex items-center gap-1">
-                            <span class="text-xs text-gray-400 mr-1">YouTube</span>
+                            <span class="text-xs text-gray-400 dark:text-gray-500 mr-1">YouTube</span>
                             <a href="/meta/{{ job.id }}"
-                               class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium border {% if job.youtube_title %}bg-green-50 text-green-700 border-green-200 hover:bg-green-100{% else %}bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100{% endif %}">
+                               class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium border {% if job.youtube_title %}bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 hover:bg-green-100{% else %}bg-gray-50 dark:bg-gray-900 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700{% endif %}">
                                 <span class="w-1.5 h-1.5 rounded-full {% if job.youtube_title %}bg-green-500{% else %}bg-gray-300{% endif %}"></span>
                                 {{ t('history.meta') }}
                             </a>
                             {% if job.youtube_title %}
                             <button onclick="showMetaModal('{{ job.id }}')"
-                                    class="inline-flex items-center rounded-full px-1.5 py-1 text-xs font-medium border bg-green-50 text-green-700 border-green-200 hover:bg-green-100" title="{{ t('history.meta') }}">
+                                    class="inline-flex items-center rounded-full px-1.5 py-1 text-xs font-medium border bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 hover:bg-green-100" title="{{ t('history.meta') }}">
                                 <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
                             </button>
                             {% endif %}
                             <button onclick="generateCatchphrase('{{ job.id }}')"
-                                    class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium border {% if job.catchphrases %}bg-green-50 text-green-700 border-green-200 hover:bg-green-100{% else %}bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100{% endif %}">
+                                    class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium border {% if job.catchphrases %}bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 hover:bg-green-100{% else %}bg-gray-50 dark:bg-gray-900 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700{% endif %}">
                                 <span class="w-1.5 h-1.5 rounded-full {% if job.catchphrases %}bg-green-500{% else %}bg-gray-300{% endif %}"></span>
                                 {{ t('history.catchphrase') }}
                             </button>
                             <button onclick="generateQuiz('{{ job.id }}')"
-                                    class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium border {% if job.quiz %}bg-green-50 text-green-700 border-green-200 hover:bg-green-100{% else %}bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100{% endif %}">
+                                    class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium border {% if job.quiz %}bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 hover:bg-green-100{% else %}bg-gray-50 dark:bg-gray-900 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700{% endif %}">
                                 <span class="w-1.5 h-1.5 rounded-full {% if job.quiz %}bg-green-500{% else %}bg-gray-300{% endif %}"></span>
                                 {{ t('history.quiz') }}
                             </button>
@@ -84,7 +84,7 @@
                         <div class="flex items-center ml-auto">
                             <button hx-delete="/api/jobs/{{ job.id }}" hx-confirm="{{ t('history.delete_confirm') }}"
                                     hx-target="#job-{{ job.id }}" hx-swap="delete"
-                                    class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-red-50 text-red-700 border-red-200 hover:bg-red-100">{{ t('history.del') }}</button>
+                                    class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium border bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-200 hover:bg-red-100">{{ t('history.del') }}</button>
                         </div>
                     </div>
                 </td>
@@ -94,7 +94,7 @@
         {% if not jobs %}
         <tbody>
             <tr>
-                <td colspan="6" class="px-6 py-8 text-center text-sm text-gray-500">{{ t('history.no_jobs') }}</td>
+                <td colspan="6" class="px-6 py-8 text-center text-sm text-gray-500 dark:text-gray-400">{{ t('history.no_jobs') }}</td>
             </tr>
         </tbody>
         {% endif %}
@@ -104,10 +104,10 @@
 <!-- Meta Modal -->
 <div id="meta-modal" style="display:none" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
      onclick="if(event.target===this)this.style.display='none'">
-    <div class="bg-white rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
         <div class="flex justify-between items-center mb-4">
             <h3 class="text-lg font-bold">{{ t('history.youtube_metadata') }}</h3>
-            <button onclick="document.getElementById('meta-modal').style.display='none'" class="text-gray-400 hover:text-gray-600 text-xl">&times;</button>
+            <button onclick="document.getElementById('meta-modal').style.display='none'" class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-xl">&times;</button>
         </div>
         <div id="meta-content" class="space-y-4"></div>
     </div>
@@ -116,16 +116,16 @@
 <!-- Catchphrase Modal -->
 <div id="catchphrase-modal" style="display:none" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
      onclick="if(event.target===this)this.style.display='none'">
-    <div class="bg-white rounded-lg p-6 max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto">
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto">
         <div class="flex justify-between items-center mb-4">
             <h3 class="text-lg font-bold">{{ t('history.thumbnail_catchphrases') }}</h3>
-            <button onclick="document.getElementById('catchphrase-modal').style.display='none'" class="text-gray-400 hover:text-gray-600 text-xl">&times;</button>
+            <button onclick="document.getElementById('catchphrase-modal').style.display='none'" class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-xl">&times;</button>
         </div>
         <div id="catchphrase-content"></div>
-        <div id="catchphrase-regen" style="display:none" class="mt-4 pt-3 border-t border-gray-200">
+        <div id="catchphrase-regen" style="display:none" class="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700">
             <div class="flex items-center gap-2">
-                <select id="catchphrase-provider" class="text-xs border-gray-300 rounded-md py-1.5 pl-2 pr-7"></select>
-                <select id="catchphrase-model" class="text-xs border-gray-300 rounded-md py-1.5 pl-2 pr-7 max-w-[200px]"></select>
+                <select id="catchphrase-provider" class="text-xs border-gray-300 dark:border-gray-600 rounded-md py-1.5 pl-2 pr-7 dark:bg-gray-800 dark:text-gray-100"></select>
+                <select id="catchphrase-model" class="text-xs border-gray-300 dark:border-gray-600 rounded-md py-1.5 pl-2 pr-7 max-w-[200px] dark:bg-gray-800 dark:text-gray-100"></select>
                 <button id="catchphrase-regen-btn" class="px-4 py-1.5 bg-purple-600 text-white rounded-md text-xs hover:bg-purple-700">{{ t('history.regenerate') }}</button>
             </div>
         </div>
@@ -135,16 +135,16 @@
 <!-- Quiz Modal -->
 <div id="quiz-modal" style="display:none" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
      onclick="if(event.target===this)this.style.display='none'">
-    <div class="bg-white rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
+    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
         <div class="flex justify-between items-center mb-4">
             <h3 class="text-lg font-bold">{{ t('history.youtube_quiz') }}</h3>
-            <button onclick="document.getElementById('quiz-modal').style.display='none'" class="text-gray-400 hover:text-gray-600">&times;</button>
+            <button onclick="document.getElementById('quiz-modal').style.display='none'" class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">&times;</button>
         </div>
         <div id="quiz-content"></div>
-        <div id="quiz-regen" style="display:none" class="mt-4 pt-3 border-t border-gray-200">
+        <div id="quiz-regen" style="display:none" class="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700">
             <div class="flex items-center gap-2">
-                <select id="quiz-provider" class="text-xs border-gray-300 rounded-md py-1.5 pl-2 pr-7"></select>
-                <select id="quiz-model" class="text-xs border-gray-300 rounded-md py-1.5 pl-2 pr-7 max-w-[200px]"></select>
+                <select id="quiz-provider" class="text-xs border-gray-300 dark:border-gray-600 rounded-md py-1.5 pl-2 pr-7 dark:bg-gray-800 dark:text-gray-100"></select>
+                <select id="quiz-model" class="text-xs border-gray-300 dark:border-gray-600 rounded-md py-1.5 pl-2 pr-7 max-w-[200px] dark:bg-gray-800 dark:text-gray-100"></select>
                 <button id="quiz-regen-btn" class="px-4 py-1.5 bg-purple-600 text-white rounded-md text-xs hover:bg-purple-700">{{ t('history.regenerate') }}</button>
             </div>
         </div>
@@ -163,28 +163,28 @@ async function showMetaModal(jobId) {
 
     content.innerHTML = `
         <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('history.label_title') }}</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('history.label_title') }}</label>
             <div class="flex">
                 <input type="text" value="${job.youtube_title || ''}" readonly
-                       class="flex-1 rounded-l-md border-gray-300 text-sm p-2 border bg-gray-50" id="meta-title">
+                       class="flex-1 rounded-l-md border-gray-300 dark:border-gray-600 text-sm p-2 border bg-gray-50 dark:bg-gray-900" id="meta-title">
                 <button onclick="navigator.clipboard.writeText(document.getElementById('meta-title').value)"
-                        class="px-3 bg-gray-100 border border-l-0 border-gray-300 rounded-r-md text-xs hover:bg-gray-200">{{ t('history.copy') }}</button>
+                        class="px-3 bg-gray-100 dark:bg-gray-800 border border-l-0 border-gray-300 dark:border-gray-600 rounded-r-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('history.copy') }}</button>
             </div>
         </div>
         <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('history.label_description') }}</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('history.label_description') }}</label>
             <textarea readonly rows="10" id="meta-desc"
-                      class="w-full rounded-md border-gray-300 text-sm p-2 border bg-gray-50">${job.youtube_description || ''}</textarea>
+                      class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border bg-gray-50 dark:bg-gray-900">${job.youtube_description || ''}</textarea>
             <button onclick="navigator.clipboard.writeText(document.getElementById('meta-desc').value)"
-                    class="mt-1 px-3 py-1 bg-gray-100 border border-gray-300 rounded-md text-xs hover:bg-gray-200">{{ t('history.copy') }}</button>
+                    class="mt-1 px-3 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('history.copy') }}</button>
         </div>
         ${tags ? `<div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('history.label_tags') }}</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('history.label_tags') }}</label>
             <div class="flex">
                 <input type="text" value="${tags}" readonly
-                       class="flex-1 rounded-l-md border-gray-300 text-sm p-2 border bg-gray-50" id="meta-tags">
+                       class="flex-1 rounded-l-md border-gray-300 dark:border-gray-600 text-sm p-2 border bg-gray-50 dark:bg-gray-900" id="meta-tags">
                 <button onclick="navigator.clipboard.writeText(document.getElementById('meta-tags').value)"
-                        class="px-3 bg-gray-100 border border-l-0 border-gray-300 rounded-r-md text-xs hover:bg-gray-200">{{ t('history.copy') }}</button>
+                        class="px-3 bg-gray-100 dark:bg-gray-800 border border-l-0 border-gray-300 dark:border-gray-600 rounded-r-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('history.copy') }}</button>
             </div>
         </div>` : ''}`;
 }
@@ -235,7 +235,7 @@ async function generateCatchphrase(jobId, regenerate = false) {
     const regenArea = document.getElementById('catchphrase-regen');
     modal.style.display = 'flex';
     regenArea.style.display = 'none';
-    content.innerHTML = '<div class="flex items-center space-x-2"><div class="animate-spin h-4 w-4 border-2 border-pink-600 border-t-transparent rounded-full"></div><span class="text-sm text-gray-600">{{ t("history.loading") }}</span></div>';
+    content.innerHTML = '<div class="flex items-center space-x-2"><div class="animate-spin h-4 w-4 border-2 border-pink-600 border-t-transparent rounded-full"></div><span class="text-sm text-gray-600 dark:text-gray-300">{{ t("history.loading") }}</span></div>';
 
     try {
         const url = `/api/jobs/${jobId}/generate-catchphrase` + (regenerate ? '?regenerate=true' : '');
@@ -248,16 +248,16 @@ async function generateCatchphrase(jobId, regenerate = false) {
         const data = await res.json();
 
         if (data.catchphrases) {
-            let html = data.cached ? '<p class="text-xs text-gray-400 mb-2">{{ t("history.saved_result") }}</p>' : '';
+            let html = data.cached ? '<p class="text-xs text-gray-400 dark:text-gray-500 mb-2">{{ t("history.saved_result") }}</p>' : '';
             html += '<div class="space-y-2">';
             data.catchphrases.forEach(p => {
                 html += `<div class="flex items-center justify-between border rounded-lg p-3">
                     <div>
                         <span class="font-bold text-lg">${p.text}</span>
-                        <span class="ml-2 text-xs text-gray-400">${p.style || ''}</span>
+                        <span class="ml-2 text-xs text-gray-400 dark:text-gray-500">${p.style || ''}</span>
                     </div>
                     <button onclick="navigator.clipboard.writeText('${p.text.replace(/'/g, "\\'")}'); this.textContent='{{ t("history.copied") }}'"
-                            class="px-2 py-1 bg-gray-100 border border-gray-300 rounded text-xs hover:bg-gray-200">{{ t("history.copy") }}</button>
+                            class="px-2 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t("history.copy") }}</button>
                 </div>`;
             });
             html += '</div>';
@@ -281,7 +281,7 @@ async function generateQuiz(jobId, regenerate = false) {
     const regenArea = document.getElementById('quiz-regen');
     modal.style.display = 'flex';
     regenArea.style.display = 'none';
-    content.innerHTML = '<div class="flex items-center space-x-2"><div class="animate-spin h-4 w-4 border-2 border-blue-600 border-t-transparent rounded-full"></div><span class="text-sm text-gray-600">{{ t("history.loading") }}</span></div>';
+    content.innerHTML = '<div class="flex items-center space-x-2"><div class="animate-spin h-4 w-4 border-2 border-blue-600 border-t-transparent rounded-full"></div><span class="text-sm text-gray-600 dark:text-gray-300">{{ t("history.loading") }}</span></div>';
 
     try {
         const url = `/api/jobs/${jobId}/generate-quiz` + (regenerate ? '?regenerate=true' : '');
@@ -294,7 +294,7 @@ async function generateQuiz(jobId, regenerate = false) {
         const data = await res.json();
 
         if (data.quiz) {
-            let html = data.cached ? '<p class="text-xs text-gray-400 mb-2">{{ t("history.saved_result") }}</p>' : '';
+            let html = data.cached ? '<p class="text-xs text-gray-400 dark:text-gray-500 mb-2">{{ t("history.saved_result") }}</p>' : '';
             html += '<div class="space-y-4">';
             data.quiz.forEach((q, i) => {
                 html += `<div class="border rounded-lg p-3">
@@ -302,7 +302,7 @@ async function generateQuiz(jobId, regenerate = false) {
                     <ul class="space-y-1">`;
                 q.options.forEach((opt, j) => {
                     const isAnswer = j === q.answer_index;
-                    html += `<li class="text-sm ${isAnswer ? 'text-green-700 font-medium' : 'text-gray-600'}">
+                    html += `<li class="text-sm ${isAnswer ? 'text-green-700 dark:text-green-300 font-medium' : 'text-gray-600 dark:text-gray-300'}">
                         ${String.fromCharCode(65+j)}. ${opt} ${isAnswer ? '{{ t("history.correct") }}' : ''}
                     </li>`;
                 });

--- a/src/templates/meta_editor.html
+++ b/src/templates/meta_editor.html
@@ -2,91 +2,91 @@
 {% block title %}{{ t('meta.title') }} - VoiceSRT{% endblock %}
 {% block content %}
 <div class="max-w-3xl mx-auto" x-data="metaEditor()" x-init="loadSavedContext(); loadModels()">
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">{{ t('meta.heading') }}</h1>
-    <p class="text-sm text-gray-500 mb-6">{{ job.filename }}{% if job.audio_duration %} ({{ "%.1f"|format(job.audio_duration) }}s){% endif %}</p>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">{{ t('meta.heading') }}</h1>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">{{ job.filename }}{% if job.audio_duration %} ({{ "%.1f"|format(job.audio_duration) }}s){% endif %}</p>
 
     <!-- Step 1: Context & Prompt Editor -->
     <div x-show="step === 'edit'" class="space-y-4">
         <!-- Channel & Video Info -->
-        <div class="bg-white shadow rounded-lg p-6">
-            <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('meta.channel_video_info') }}</h2>
-            <p class="text-sm text-gray-500 mb-4">{{ t('meta.channel_info_desc') }}</p>
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('meta.channel_video_info') }}</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ t('meta.channel_info_desc') }}</p>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.channel_name') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.channel_name') }}</label>
                     <input type="text" x-model="context.channelName"
-                           class="w-full rounded-md border-gray-300 text-sm p-2 border"
+                           class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100"
                            placeholder="{{ t('meta.channel_name_placeholder') }}">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.genre') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.genre') }}</label>
                     <input type="text" x-model="context.genre"
-                           class="w-full rounded-md border-gray-300 text-sm p-2 border"
+                           class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100"
                            placeholder="{{ t('meta.genre_placeholder') }}">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.speakers') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.speakers') }}</label>
                     <input type="text" x-model="context.speakers"
-                           class="w-full rounded-md border-gray-300 text-sm p-2 border"
+                           class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100"
                            placeholder="{{ t('meta.speakers_placeholder') }}">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.target_audience') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.target_audience') }}</label>
                     <input type="text" x-model="context.audience"
-                           class="w-full rounded-md border-gray-300 text-sm p-2 border"
+                           class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100"
                            placeholder="{{ t('meta.target_audience_placeholder') }}">
                 </div>
             </div>
             <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.additional_notes') }}</label>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.additional_notes') }}</label>
                 <textarea x-model="context.notes" rows="2"
-                          class="w-full rounded-md border-gray-300 text-sm p-2 border"
+                          class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100"
                           placeholder="{{ t('meta.additional_notes_placeholder') }}"></textarea>
             </div>
             <!-- Tone Reference Toggle -->
-            <div class="flex items-center justify-between pt-3 border-t border-gray-200">
+            <div class="flex items-center justify-between pt-3 border-t border-gray-200 dark:border-gray-700">
                 <div class="flex items-center">
                     <input type="checkbox" x-model="useToneRef" id="tone-ref-toggle"
-                           class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-                    <label for="tone-ref-toggle" class="ml-2 text-sm font-medium text-gray-700">{{ t('meta.use_tone_ref') }}</label>
+                           class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
+                    <label for="tone-ref-toggle" class="ml-2 text-sm font-medium text-gray-700 dark:text-gray-200">{{ t('meta.use_tone_ref') }}</label>
                 </div>
                 <a href="/settings#tone-references" class="text-xs text-blue-600 hover:text-blue-800">{{ t('meta.tone_ref_link') }} &rarr;</a>
             </div>
         </div>
 
         <!-- Description Template & Fixed Footer -->
-        <div class="bg-white shadow rounded-lg p-6">
-            <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('meta.description_settings') }}</h2>
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('meta.description_settings') }}</h2>
             <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.description_template') }}</label>
-                <p class="text-xs text-gray-500 mb-1">{{ t('meta.description_template_desc') }}</p>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.description_template') }}</label>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">{{ t('meta.description_template_desc') }}</p>
                 <textarea x-model="context.descriptionTemplate" rows="4"
-                          class="w-full rounded-md border-gray-300 text-sm p-2 border font-mono"
+                          class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"
                           placeholder="{{ t('meta.description_template_placeholder') }}"></textarea>
             </div>
             <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.fixed_footer') }}</label>
-                <p class="text-xs text-gray-500 mb-1">{{ t('meta.fixed_footer_desc') }}</p>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.fixed_footer') }}</label>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">{{ t('meta.fixed_footer_desc') }}</p>
                 <textarea x-model="context.fixedFooter" rows="4"
-                          class="w-full rounded-md border-gray-300 text-sm p-2 border font-mono"
+                          class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"
                           placeholder="{{ t('meta.fixed_footer_placeholder') }}"></textarea>
             </div>
         </div>
 
         <!-- Prompt & LLM -->
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
             <div class="flex items-center justify-between mb-4">
-                <h2 class="text-lg font-medium text-gray-900">{{ t('meta.prompt') }}</h2>
+                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ t('meta.prompt') }}</h2>
                 <!-- LLM model selector — applies to both Optimize and Generate -->
                 <div class="flex items-center gap-2">
-                    <span class="text-xs text-gray-500">{{ t('meta.llm_label') }}</span>
-                    <select x-model="selectedProvider" @change="onProviderChange()" class="text-xs border-gray-300 rounded-md py-1.5 pl-2 pr-7">
+                    <span class="text-xs text-gray-500 dark:text-gray-400">{{ t('meta.llm_label') }}</span>
+                    <select x-model="selectedProvider" @change="onProviderChange()" class="text-xs border-gray-300 dark:border-gray-600 rounded-md py-1.5 pl-2 pr-7 dark:bg-gray-800 dark:text-gray-100">
                         <template x-for="p in availableProviders" :key="p">
                             <option :value="p" x-text="p" :disabled="!hasKey[p]"></option>
                         </template>
                     </select>
-                    <select x-model="selectedModel" class="text-xs border-gray-300 rounded-md py-1.5 pl-2 pr-7 max-w-[200px]">
+                    <select x-model="selectedModel" class="text-xs border-gray-300 dark:border-gray-600 rounded-md py-1.5 pl-2 pr-7 max-w-[200px] dark:bg-gray-800 dark:text-gray-100">
                         <template x-for="m in currentModels" :key="m">
                             <option :value="m" x-text="m"></option>
                         </template>
@@ -94,10 +94,10 @@
                 </div>
             </div>
             <textarea x-model="prompt" rows="12"
-                      class="w-full rounded-md border-gray-300 text-sm p-2 border font-mono"></textarea>
+                      class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"></textarea>
             <div class="mt-3 flex justify-between items-center">
                 <div class="flex items-center gap-2">
-                    <button @click="resetPrompt()" class="text-sm text-gray-500 hover:text-gray-700">{{ t('meta.reset_to_default') }}</button>
+                    <button @click="resetPrompt()" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">{{ t('meta.reset_to_default') }}</button>
                     <button @click="optimizePrompt()" :disabled="optimizing || !selectedModel"
                             class="px-4 py-2 bg-purple-100 text-purple-700 border border-purple-300 rounded-md text-sm font-medium hover:bg-purple-200 disabled:opacity-50">
                         <span x-show="!optimizing">{{ t('meta.optimize_with_ai') }}</span>
@@ -115,9 +115,9 @@
 
     <!-- Step 2: Results -->
     <div x-show="step === 'result'" class="space-y-4">
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
             <div class="flex items-center justify-between mb-4">
-                <h2 class="text-lg font-medium text-gray-900">{{ t('meta.generated_metadata') }}</h2>
+                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ t('meta.generated_metadata') }}</h2>
                 <div class="space-x-2">
                     <button @click="step = 'edit'"
                             class="px-4 py-2 bg-purple-600 text-white rounded-md text-sm font-medium hover:bg-purple-700">
@@ -131,16 +131,16 @@
             </div>
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.label_title') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.label_title') }}</label>
                     <template x-if="Array.isArray(result.titles) && result.titles.length > 0">
                         <div class="space-y-2">
                             <template x-for="(titleOpt, i) in result.titles" :key="i">
                                 <div class="flex">
-                                    <span class="inline-flex items-center px-2 bg-gray-50 border border-r-0 border-gray-300 rounded-l-md text-xs text-gray-500" x-text="i + 1"></span>
+                                    <span class="inline-flex items-center px-2 bg-gray-50 dark:bg-gray-900 border border-r-0 border-gray-300 dark:border-gray-600 rounded-l-md text-xs text-gray-500 dark:text-gray-400" x-text="i + 1"></span>
                                     <input type="text" :value="titleOpt" readonly
-                                           class="flex-1 border-gray-300 text-sm p-2 border bg-gray-50">
+                                           class="flex-1 border-gray-300 dark:border-gray-600 text-sm p-2 border bg-gray-50 dark:bg-gray-900">
                                     <button @click="copyText(titleOpt)"
-                                            class="px-3 bg-gray-100 border border-l-0 border-gray-300 rounded-r-md text-xs hover:bg-gray-200">{{ t('meta.copy') }}</button>
+                                            class="px-3 bg-gray-100 dark:bg-gray-800 border border-l-0 border-gray-300 dark:border-gray-600 rounded-r-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('meta.copy') }}</button>
                                 </div>
                             </template>
                         </div>
@@ -148,28 +148,28 @@
                     <template x-if="!Array.isArray(result.titles) || result.titles.length === 0">
                         <div class="flex">
                             <input type="text" x-model="result.title" readonly
-                                   class="flex-1 rounded-l-md border-gray-300 text-sm p-2 border bg-gray-50">
+                                   class="flex-1 rounded-l-md border-gray-300 dark:border-gray-600 text-sm p-2 border bg-gray-50 dark:bg-gray-900">
                             <button @click="copyText(result.title)"
-                                    class="px-3 bg-gray-100 border border-l-0 border-gray-300 rounded-r-md text-xs hover:bg-gray-200">{{ t('meta.copy') }}</button>
+                                    class="px-3 bg-gray-100 dark:bg-gray-800 border border-l-0 border-gray-300 dark:border-gray-600 rounded-r-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('meta.copy') }}</button>
                         </div>
                     </template>
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.label_description') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.label_description') }}</label>
                     <textarea x-model="result.description" readonly rows="14"
-                              class="w-full rounded-md border-gray-300 text-sm p-2 border bg-gray-50"></textarea>
+                              class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border bg-gray-50 dark:bg-gray-900"></textarea>
                     <button @click="copyText(result.description)"
-                            class="mt-1 px-3 py-1 bg-gray-100 border border-gray-300 rounded-md text-xs hover:bg-gray-200">{{ t('meta.copy_description') }}</button>
+                            class="mt-1 px-3 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('meta.copy_description') }}</button>
                 </div>
                 <div x-show="result.tags && result.tags.length > 0">
-                    <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('meta.label_tags') }}</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('meta.label_tags') }}</label>
                     <div class="flex flex-wrap gap-1 mb-2">
                         <template x-for="tag in result.tags" :key="tag">
-                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800" x-text="tag"></span>
+                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300" x-text="tag"></span>
                         </template>
                     </div>
                     <button @click="copyText(result.tags.join(','))"
-                            class="px-3 py-1 bg-gray-100 border border-gray-300 rounded-md text-xs hover:bg-gray-200">{{ t('meta.copy_tags') }}</button>
+                            class="px-3 py-1 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('meta.copy_tags') }}</button>
                 </div>
             </div>
         </div>

--- a/src/templates/partials/job_status.html
+++ b/src/templates/partials/job_status.html
@@ -1,15 +1,15 @@
 {% set status_colors = {
-    'pending': 'bg-gray-100 text-gray-800',
-    'extracting': 'bg-yellow-100 text-yellow-800',
-    'transcribing': 'bg-blue-100 text-blue-800',
-    'refining': 'bg-cyan-100 text-cyan-800',
-    'verifying': 'bg-amber-100 text-amber-800',
-    'generating_metadata': 'bg-purple-100 text-purple-800',
+    'pending': 'bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200',
+    'extracting': 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300',
+    'transcribing': 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300',
+    'refining': 'bg-cyan-100 dark:bg-cyan-900/40 text-cyan-800 dark:text-cyan-300',
+    'verifying': 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300',
+    'generating_metadata': 'bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-300',
 
-    'completed': 'bg-green-100 text-green-800',
-    'failed': 'bg-red-100 text-red-800',
+    'completed': 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300',
+    'failed': 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300',
 } %}
-{% set color = status_colors.get(job.status, 'bg-gray-100 text-gray-800') %}
+{% set color = status_colors.get(job.status, 'bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200') %}
 {% set is_done = job.status in ('completed', 'failed') %}
 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ color }}">
     {% if not is_done %}
@@ -20,12 +20,12 @@
 {% if job.error_message %}
 {% set is_warning = job.status == 'completed' %}
 {% set error_lines = job.error_message.splitlines() %}
-<div class="mt-2 p-3 {{ 'bg-yellow-50 border-yellow-200' if is_warning else 'bg-red-50 border-red-200' }} border rounded-md">
-    <p class="text-xs font-medium {{ 'text-yellow-800' if is_warning else 'text-red-800' }}">
+<div class="mt-2 p-3 {{ 'bg-yellow-50 dark:bg-yellow-900/30 border-yellow-200' if is_warning else 'bg-red-50 dark:bg-red-900/30 border-red-200' }} border rounded-md">
+    <p class="text-xs font-medium {{ 'text-yellow-800 dark:text-yellow-300' if is_warning else 'text-red-800 dark:text-red-300' }}">
         {{ '⚠' if is_warning else '✗' }} {{ error_lines[0] }}
     </p>
     {% if error_lines|length > 1 %}
-    <p class="text-xs {{ 'text-yellow-700' if is_warning else 'text-red-700' }} mt-1">
+    <p class="text-xs {{ 'text-yellow-700 dark:text-yellow-300' if is_warning else 'text-red-700 dark:text-red-300' }} mt-1">
         → {{ error_lines[1] }}
     </p>
     {% endif %}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1,34 +1,34 @@
 {% extends "base.html" %}
 {% block title %}{{ t('settings.title') }} - VoiceSRT{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold text-gray-900 mb-6">{{ t('settings.title') }}</h1>
+<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{{ t('settings.title') }}</h1>
 
 <div class="space-y-6" x-data="settingsPage()" x-init="loadSettings()">
     <!-- API Keys -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('settings.api_keys') }}</h2>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('settings.api_keys') }}</h2>
         <div class="space-y-4">
             <template x-for="p in providers" :key="p.id">
                 <div class="border rounded-lg p-4">
                     <div class="flex items-center justify-between mb-2">
-                        <h3 class="font-medium text-gray-900" x-text="p.label"></h3>
-                        <span x-show="p.configured" class="text-xs bg-green-100 text-green-800 px-2 py-1 rounded-full">{{ t('settings.configured') }}</span>
+                        <h3 class="font-medium text-gray-900 dark:text-gray-100" x-text="p.label"></h3>
+                        <span x-show="p.configured" class="text-xs bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300 px-2 py-1 rounded-full">{{ t('settings.configured') }}</span>
                     </div>
                     <div class="flex space-x-2">
                         <input :type="p.showKey ? 'text' : 'password'"
                                x-model="p.newKey"
                                :placeholder="p.configured ? p.masked : '{{ t('settings.enter_api_key') }}'"
-                               class="flex-1 rounded-md border-gray-300 text-sm p-2 border">
+                               class="flex-1 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                         <button @click="saveKey(p)" :disabled="!p.newKey"
                                 class="px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700 disabled:bg-gray-400">
                             {{ t('settings.save') }}
                         </button>
                         <button @click="testKey(p)" :disabled="!p.configured"
-                                class="px-4 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm hover:bg-gray-200 disabled:opacity-50">
+                                class="px-4 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-sm hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50">
                             {{ t('settings.test') }}
                         </button>
                         <button x-show="p.configured" @click="deleteKey(p)"
-                                class="px-4 py-2 bg-red-100 text-red-700 rounded-md text-sm hover:bg-red-200">
+                                class="px-4 py-2 bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 rounded-md text-sm hover:bg-red-200">
                             {{ t('settings.del') }}
                         </button>
                     </div>
@@ -42,20 +42,20 @@
     </div>
 
     <!-- Ollama Settings -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-2">{{ t('settings.ollama_title') }}</h2>
-        <p class="text-sm text-gray-500 mb-4">{{ t('settings.ollama_desc') }}</p>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{{ t('settings.ollama_title') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ t('settings.ollama_desc') }}</p>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-                <label class="block text-xs text-gray-500 mb-1">{{ t('settings.ollama_base_url') }}</label>
+                <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1">{{ t('settings.ollama_base_url') }}</label>
                 <div class="flex space-x-2">
                     <input type="text" x-model="ollamaUrl"
-                           class="flex-1 rounded-md border-gray-300 text-sm p-2 border"
+                           class="flex-1 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100"
                            placeholder="http://host.docker.internal:11434">
                     <button @click="saveOllamaUrl()"
                             class="px-3 py-2 bg-blue-600 text-white rounded-md text-xs hover:bg-blue-700">{{ t('settings.save') }}</button>
                     <button @click="testOllama()"
-                            class="px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-xs hover:bg-gray-200">{{ t('settings.test') }}</button>
+                            class="px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-xs hover:bg-gray-200 dark:hover:bg-gray-600">{{ t('settings.test') }}</button>
                 </div>
                 <p x-show="ollamaTestResult !== null" class="mt-2 text-sm"
                    :class="ollamaTestResult ? 'text-green-600' : 'text-red-600'"
@@ -65,9 +65,9 @@
     </div>
 
     <!-- LLM Models -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-2">{{ t('settings.llm_models') }}</h2>
-        <p class="text-sm text-gray-500 mb-4">
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{{ t('settings.llm_models') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
             {{ t('settings.configure_models') }}
             <a href="https://openai.com/api/pricing/" target="_blank" class="text-blue-600 hover:underline">OpenAI Pricing</a> |
             <a href="https://ai.google.dev/gemini-api/docs/pricing" target="_blank" class="text-blue-600 hover:underline">Gemini Pricing</a>
@@ -75,33 +75,33 @@
 
         <!-- Presets -->
         <div class="mb-4">
-            <label class="block text-sm font-medium text-gray-700 mb-2">{{ t('settings.quick_presets') }}</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">{{ t('settings.quick_presets') }}</label>
             <div class="flex space-x-2">
                 <button @click="applyPreset('quality')"
                         class="px-4 py-2 bg-purple-100 text-purple-700 border border-purple-300 rounded-md text-sm hover:bg-purple-200 font-medium">
                     {{ t('settings.quality') }}
                 </button>
                 <button @click="applyPreset('balanced')"
-                        class="px-4 py-2 bg-blue-100 text-blue-700 border border-blue-300 rounded-md text-sm hover:bg-blue-200 font-medium">
+                        class="px-4 py-2 bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 border border-blue-300 rounded-md text-sm hover:bg-blue-200 font-medium">
                     {{ t('settings.balanced') }}
                 </button>
                 <button @click="applyPreset('budget')"
-                        class="px-4 py-2 bg-green-100 text-green-700 border border-green-300 rounded-md text-sm hover:bg-green-200 font-medium">
+                        class="px-4 py-2 bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 border border-green-300 rounded-md text-sm hover:bg-green-200 font-medium">
                     {{ t('settings.budget') }}
                 </button>
             </div>
-            <p class="mt-2 text-xs text-gray-500" x-text="presetDescription"></p>
+            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400" x-text="presetDescription"></p>
         </div>
 
         <!-- Default models (per provider) -->
-        <h3 class="text-sm font-medium text-gray-700 mb-1 mt-4">{{ t('settings.default_models') }}</h3>
-        <p class="text-xs text-gray-500 mb-3">{{ t('settings.default_models_desc') }}</p>
+        <h3 class="text-sm font-medium text-gray-700 dark:text-gray-200 mb-1 mt-4">{{ t('settings.default_models') }}</h3>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">{{ t('settings.default_models_desc') }}</p>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
             <div>
-                <label class="block text-xs text-gray-500 mb-1">OpenAI</label>
+                <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1">OpenAI</label>
                 <div class="flex space-x-2">
                     <select x-model="models.openai"
-                            class="flex-1 min-w-0 rounded-md border-gray-300 text-sm p-2 border">
+                            class="flex-1 min-w-0 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                         <template x-for="m in openaiModels" :key="m">
                             <option :value="m" x-text="m"></option>
                         </template>
@@ -111,10 +111,10 @@
                 </div>
             </div>
             <div>
-                <label class="block text-xs text-gray-500 mb-1">Gemini</label>
+                <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Gemini</label>
                 <div class="flex space-x-2">
                     <select x-model="models.gemini"
-                            class="flex-1 min-w-0 rounded-md border-gray-300 text-sm p-2 border">
+                            class="flex-1 min-w-0 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                         <template x-for="m in geminiModels" :key="m">
                             <option :value="m" x-text="m"></option>
                         </template>
@@ -124,10 +124,10 @@
                 </div>
             </div>
             <div>
-                <label class="block text-xs text-gray-500 mb-1">Ollama</label>
+                <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1">Ollama</label>
                 <div class="flex space-x-2">
                     <select x-model="models.ollama"
-                            class="flex-1 min-w-0 rounded-md border-gray-300 text-sm p-2 border truncate">
+                            class="flex-1 min-w-0 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border truncate dark:bg-gray-800 dark:text-gray-100">
                         <template x-for="m in ollamaModels" :key="m">
                             <option :value="m" x-text="m"></option>
                         </template>
@@ -140,15 +140,15 @@
         </div>
 
         <!-- Refine override models -->
-        <h3 class="text-sm font-medium text-gray-700 mb-1">{{ t('settings.refine_models') }}</h3>
-        <p class="text-xs text-gray-500 mb-3">{{ t('settings.refine_models_hint') }}</p>
+        <h3 class="text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('settings.refine_models') }}</h3>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">{{ t('settings.refine_models_hint') }}</p>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             <template x-for="(info, key) in generalSettings" :key="key">
                 <div x-show="key.startsWith('refine_model')">
-                    <label class="block text-xs text-gray-500 mb-1" x-text="info.label"></label>
+                    <label class="block text-xs text-gray-500 dark:text-gray-400 mb-1" x-text="info.label"></label>
                     <div class="flex space-x-2">
                         <select x-model="info.value"
-                                class="flex-1 min-w-0 rounded-md border-gray-300 text-sm p-2 border truncate">
+                                class="flex-1 min-w-0 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border truncate dark:bg-gray-800 dark:text-gray-100">
                             <option value="">—</option>
                             <template x-for="m in (key === 'refine_model_openai' ? openaiModels : key === 'refine_model_gemini' ? geminiModels : ollamaModels)" :key="m">
                                 <option :value="m" x-text="m"></option>
@@ -163,15 +163,15 @@
     </div>
 
     <!-- General Settings -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('settings.general') }}</h2>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('settings.general') }}</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <template x-for="(info, key) in generalSettings" :key="key">
                 <div x-show="!key.startsWith('refine_model')">
-                    <label class="block text-sm font-medium text-gray-700 mb-1" x-text="info.label"></label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" x-text="info.label"></label>
                     <div class="flex space-x-2">
                         <input type="text" x-model="info.value"
-                               class="flex-1 rounded-md border-gray-300 text-sm p-2 border">
+                               class="flex-1 rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                         <button @click="saveGeneral(key, info.value)"
                                 class="px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700">{{ t('settings.save') }}</button>
                     </div>
@@ -181,37 +181,37 @@
     </div>
 
     <!-- Pricing -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-2">{{ t('settings.pricing') }}</h2>
-        <p class="text-sm text-gray-500 mb-4">{{ t('settings.pricing_desc') }}</p>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{{ t('settings.pricing') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ t('settings.pricing_desc') }}</p>
         <div class="overflow-x-auto">
             <table class="min-w-full text-sm">
                 <thead>
                     <tr class="border-b">
-                        <th class="text-left py-2 pr-4 font-medium text-gray-700">{{ t('settings.model') }}</th>
-                        <th class="text-left py-2 px-2 font-medium text-gray-700">{{ t('settings.input_1m') }}</th>
-                        <th class="text-left py-2 px-2 font-medium text-gray-700">{{ t('settings.output_1m') }}</th>
-                        <th class="text-left py-2 px-2 font-medium text-gray-700">{{ t('settings.per_min') }}</th>
+                        <th class="text-left py-2 pr-4 font-medium text-gray-700 dark:text-gray-200">{{ t('settings.model') }}</th>
+                        <th class="text-left py-2 px-2 font-medium text-gray-700 dark:text-gray-200">{{ t('settings.input_1m') }}</th>
+                        <th class="text-left py-2 px-2 font-medium text-gray-700 dark:text-gray-200">{{ t('settings.output_1m') }}</th>
+                        <th class="text-left py-2 px-2 font-medium text-gray-700 dark:text-gray-200">{{ t('settings.per_min') }}</th>
                     </tr>
                 </thead>
                 <tbody>
                     <template x-for="[model, prices] in Object.entries(pricing)" :key="model">
-                        <tr class="border-b border-gray-100"
-                            :class="{ 'bg-gray-50': model === 'whisper-1' }">
+                        <tr class="border-b border-gray-100 dark:border-gray-700"
+                            :class="{ 'bg-gray-50 dark:bg-gray-900': model === 'whisper-1' }">
                             <td class="py-1.5 pr-4 font-mono text-xs" x-text="model"></td>
                             <td class="py-1.5 px-2">
                                 <input type="number" step="0.01" x-model.number="prices.input_per_1m"
-                                       class="w-20 rounded border-gray-300 text-xs p-1 border">
+                                       class="w-20 rounded border-gray-300 dark:border-gray-600 text-xs p-1 border dark:bg-gray-800 dark:text-gray-100">
                             </td>
                             <td class="py-1.5 px-2">
                                 <input type="number" step="0.01" x-model.number="prices.output_per_1m"
-                                       class="w-20 rounded border-gray-300 text-xs p-1 border">
+                                       class="w-20 rounded border-gray-300 dark:border-gray-600 text-xs p-1 border dark:bg-gray-800 dark:text-gray-100">
                             </td>
                             <td class="py-1.5 px-2">
                                 <input x-show="prices.per_minute !== undefined" type="number" step="0.001"
                                        x-model.number="prices.per_minute"
-                                       class="w-20 rounded border-gray-300 text-xs p-1 border">
-                                <span x-show="prices.per_minute === undefined" class="text-gray-400 text-xs">-</span>
+                                       class="w-20 rounded border-gray-300 dark:border-gray-600 text-xs p-1 border dark:bg-gray-800 dark:text-gray-100">
+                                <span x-show="prices.per_minute === undefined" class="text-gray-400 dark:text-gray-500 text-xs">-</span>
                             </td>
                         </tr>
                     </template>
@@ -223,13 +223,13 @@
     </div>
 
     <!-- Glossary -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('settings.glossary') }}</h2>
-        <p class="text-sm text-gray-500 mb-2">
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('settings.glossary') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
             {{ t('settings.glossary_desc') }}
         </p>
         <textarea x-model="glossary" rows="6"
-                  class="w-full rounded-md border-gray-300 text-sm p-2 border font-mono"
+                  class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"
                   placeholder="VoiceSRT&#10;John Smith&#10;Kubernetes&#10;Next.js"></textarea>
         <button @click="saveGlossary()"
                 class="mt-2 px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700">{{ t('settings.save_glossary') }}</button>
@@ -237,31 +237,31 @@
 
 
     <!-- Tone References -->
-    <div id="tone-references" class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-4">{{ t('settings.tone_references') }}</h2>
-        <p class="text-sm text-gray-500 mb-2">
+    <div id="tone-references" class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{{ t('settings.tone_references') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
             {{ t('settings.tone_references_desc') }}
         </p>
         <textarea x-model="toneReferences" rows="10"
-                  class="w-full rounded-md border-gray-300 text-sm p-2 border font-mono"
+                  class="w-full rounded-md border-gray-300 dark:border-gray-600 text-sm p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"
                   :placeholder="'{{ t('settings.tone_references_placeholder') }}'"></textarea>
         <button @click="saveToneReferences()"
                 class="mt-2 px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700">{{ t('settings.save_tone_references') }}</button>
     </div>
 
     <!-- Refine Prompts -->
-    <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-2">{{ t('settings.refine_prompts') }}</h2>
-        <p class="text-sm text-gray-500 mb-4">{{ t('settings.refine_prompts_desc') }}</p>
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{{ t('settings.refine_prompts') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ t('settings.refine_prompts_desc') }}</p>
         <template x-for="mode in ['verbatim', 'standard', 'caption']" :key="mode">
             <div class="mb-4">
                 <div class="flex items-center justify-between mb-1">
-                    <label class="text-sm font-medium text-gray-700" x-text="mode.charAt(0).toUpperCase() + mode.slice(1)"></label>
+                    <label class="text-sm font-medium text-gray-700 dark:text-gray-200" x-text="mode.charAt(0).toUpperCase() + mode.slice(1)"></label>
                     <button @click="resetRefinePrompt(mode)"
-                            class="text-xs text-gray-500 hover:text-gray-700">{{ t('settings.reset_default') }}</button>
+                            class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">{{ t('settings.reset_default') }}</button>
                 </div>
                 <textarea x-model="refinePrompts[mode]" rows="8"
-                          class="w-full rounded-md border-gray-300 text-xs p-2 border font-mono"></textarea>
+                          class="w-full rounded-md border-gray-300 dark:border-gray-600 text-xs p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"></textarea>
                 <button @click="saveRefinePrompt(mode)"
                         class="mt-1 px-3 py-1 bg-blue-600 text-white rounded-md text-xs hover:bg-blue-700">{{ t('settings.save_prompt') }}</button>
             </div>

--- a/src/templates/setup.html
+++ b/src/templates/setup.html
@@ -6,12 +6,12 @@
     <div class="flex items-center justify-center mb-8 gap-2">
         <template x-for="s in 3" :key="s">
             <div class="flex items-center">
-                <div :class="step >= s ? 'bg-indigo-600 text-white' : 'bg-gray-200 text-gray-500'"
+                <div :class="step >= s ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400'"
                      class="w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors">
                     <span x-text="s"></span>
                 </div>
                 <div x-show="s < 3" class="w-12 h-0.5 mx-1"
-                     :class="step > s ? 'bg-indigo-600' : 'bg-gray-200'"></div>
+                     :class="step > s ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'"></div>
             </div>
         </template>
     </div>
@@ -19,32 +19,32 @@
     <!-- Step 1: Choose provider -->
     <div x-show="step === 1" x-transition>
         <h2 class="text-2xl font-bold text-center mb-2">{{ t('setup.welcome') }}</h2>
-        <p class="text-gray-600 text-center mb-8">{{ t('setup.choose_provider') }}</p>
+        <p class="text-gray-600 dark:text-gray-300 text-center mb-8">{{ t('setup.choose_provider') }}</p>
 
         <div class="space-y-3">
             <button @click="provider = 'openai'; step = 2"
                     class="w-full p-4 border-2 rounded-lg text-left hover:border-indigo-500 hover:bg-indigo-50 transition-colors"
-                    :class="provider === 'openai' ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200'">
+                    :class="provider === 'openai' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30' : 'border-gray-200 dark:border-gray-700'">
                 <div class="font-medium">{{ t('setup.openai_label') }}</div>
-                <div class="text-sm text-gray-500 mt-1">{{ t('setup.openai_desc') }}</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ t('setup.openai_desc') }}</div>
             </button>
             <button @click="provider = 'google'; step = 2"
                     class="w-full p-4 border-2 rounded-lg text-left hover:border-indigo-500 hover:bg-indigo-50 transition-colors"
-                    :class="provider === 'google' ? 'border-indigo-500 bg-indigo-50' : 'border-gray-200'">
+                    :class="provider === 'google' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/30' : 'border-gray-200 dark:border-gray-700'">
                 <div class="font-medium">{{ t('setup.google_label') }}</div>
-                <div class="text-sm text-gray-500 mt-1">{{ t('setup.google_desc') }}</div>
+                <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ t('setup.google_desc') }}</div>
             </button>
         </div>
 
         <p class="text-center mt-6">
-            <a href="/settings" class="text-sm text-gray-500 hover:text-gray-700 underline">{{ t('setup.advanced_settings') }}</a>
+            <a href="/settings" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline">{{ t('setup.advanced_settings') }}</a>
         </p>
     </div>
 
     <!-- Step 2: Enter API key -->
     <div x-show="step === 2" x-transition>
         <h2 class="text-2xl font-bold text-center mb-2">{{ t('setup.enter_key') }}</h2>
-        <p class="text-gray-600 text-center mb-6">
+        <p class="text-gray-600 dark:text-gray-300 text-center mb-6">
             <span x-show="provider === 'openai'">{{ t('setup.openai_key_hint') }}</span>
             <span x-show="provider === 'google'">{{ t('setup.google_key_hint') }}</span>
         </p>
@@ -52,14 +52,14 @@
         <div class="space-y-4">
             <input type="password" x-model="apiKey"
                    :placeholder="provider === 'openai' ? 'sk-...' : 'AIza...'"
-                   class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                   class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-800 dark:text-gray-100"
                    @keydown.enter="saveKey()">
 
             <div x-show="error" class="text-sm text-red-600" x-text="error"></div>
             <div x-show="testResult === 'valid'" class="text-sm text-green-600">{{ t('settings.key_valid') }}</div>
 
             <div class="flex gap-3">
-                <button @click="step = 1" class="px-4 py-2 text-gray-600 hover:text-gray-800">{{ t('setup.back') }}</button>
+                <button @click="step = 1" class="px-4 py-2 text-gray-600 dark:text-gray-300 hover:text-gray-800">{{ t('setup.back') }}</button>
                 <button @click="saveKey()" :disabled="!apiKey || saving"
                         class="flex-1 px-4 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 font-medium">
                     <span x-show="!saving">{{ t('setup.save_and_test') }}</span>
@@ -74,12 +74,12 @@
         <div class="text-center">
             <div class="text-5xl mb-4">&#10003;</div>
             <h2 class="text-2xl font-bold mb-2">{{ t('setup.ready') }}</h2>
-            <p class="text-gray-600 mb-8">{{ t('setup.ready_desc') }}</p>
+            <p class="text-gray-600 dark:text-gray-300 mb-8">{{ t('setup.ready_desc') }}</p>
             <a href="/" class="inline-block px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 font-medium">
                 {{ t('setup.start_upload') }}
             </a>
             <p class="mt-4">
-                <a href="/settings" class="text-sm text-gray-500 hover:text-gray-700 underline">{{ t('setup.advanced_settings') }}</a>
+                <a href="/settings" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline">{{ t('setup.advanced_settings') }}</a>
             </p>
         </div>
     </div>

--- a/src/templates/srt_editor.html
+++ b/src/templates/srt_editor.html
@@ -83,14 +83,14 @@ window.srtEditor = function () {
 {% endblock %}
 {% block content %}
 <div class="max-w-4xl mx-auto" x-data="srtEditor()" x-init="loadSegments(); initKeyboard()">
-    <div class="sticky top-0 z-10 bg-gray-50 pb-4 pt-2 -mx-4 px-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+    <div class="sticky top-0 z-10 bg-gray-50 dark:bg-gray-900 pb-4 pt-2 -mx-4 px-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
         <div class="flex items-center justify-between">
             <div>
-                <h1 class="text-2xl font-bold text-gray-900">{{ t('srt_editor.title') }}</h1>
-                <p class="text-sm text-gray-500 mt-1">{{ job.filename }}</p>
+                <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{{ t('srt_editor.title') }}</h1>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ job.filename }}</p>
             </div>
             <div class="flex items-center gap-2">
-                <span x-show="saving" class="text-xs text-gray-400">{{ t('srt_editor.saving') }}</span>
+                <span x-show="saving" class="text-xs text-gray-400 dark:text-gray-500">{{ t('srt_editor.saving') }}</span>
                 <span x-show="saveMsg && !saveError" x-transition class="text-xs text-green-600" x-text="saveMsg"></span>
                 <span x-show="saveMsg && saveError" x-transition class="text-xs text-red-600" x-text="saveMsg"></span>
                 <div class="relative" x-data="{ showGlossary: false }" @glossary-saved.window="showGlossary = false">
@@ -101,12 +101,12 @@ window.srtEditor = function () {
                         {{ t('srt_editor.glossary_label_short') }}
                     </button>
                     <div x-show="showGlossary" x-transition @click.away="showGlossary = false"
-                         class="absolute right-0 top-full mt-1 w-96 bg-white shadow-lg rounded-lg border p-3 z-50">
-                        <label class="block text-xs font-medium text-gray-700 mb-1">{{ t('srt_editor.glossary_label') }}</label>
+                         class="absolute right-0 top-full mt-1 w-96 bg-white dark:bg-gray-800 shadow-lg rounded-lg border p-3 z-50">
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('srt_editor.glossary_label') }}</label>
                         <textarea x-model="glossary" rows="6"
-                                  class="w-full rounded-md border-gray-300 text-xs p-2 border font-mono"
+                                  class="w-full rounded-md border-gray-300 dark:border-gray-600 text-xs p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"
                                   placeholder="{{ t('srt_editor.glossary_placeholder') }}"></textarea>
-                        <p class="text-xs text-gray-400 mt-1">{{ t('srt_editor.glossary_hint') }}</p>
+                        <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">{{ t('srt_editor.glossary_hint') }}</p>
                         <div class="flex justify-end mt-2">
                             <button @click="saveGlossary()"
                                     class="text-xs px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">
@@ -124,11 +124,11 @@ window.srtEditor = function () {
                         {{ t('srt_editor.speakers') }}
                     </button>
                     <div x-show="showSpeakers" x-transition @click.away="showSpeakers = false"
-                         class="absolute right-0 top-full mt-1 w-72 bg-white shadow-lg rounded-lg border p-3 z-50">
-                        <label class="block text-xs font-medium text-gray-700 mb-1">{{ t('srt_editor.speakers_label') }}</label>
+                         class="absolute right-0 top-full mt-1 w-72 bg-white dark:bg-gray-800 shadow-lg rounded-lg border p-3 z-50">
+                        <label class="block text-xs font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('srt_editor.speakers_label') }}</label>
                         <input type="text" x-model="speakerInput"
                                @keydown.enter.prevent="addSpeaker()"
-                               class="w-full rounded-md border-gray-300 text-xs p-2 border"
+                               class="w-full rounded-md border-gray-300 dark:border-gray-600 text-xs p-2 border dark:bg-gray-800 dark:text-gray-100"
                                placeholder="{{ t('srt_editor.speaker_add_placeholder') }}">
                         <div class="flex flex-wrap gap-1 mt-2">
                             <template x-for="(sp, i) in speakers" :key="i">
@@ -148,22 +148,22 @@ window.srtEditor = function () {
                     </div>
                 </div>
                 <div class="relative" x-data="{ showSrtMenu: false }">
-                    <div class="inline-flex rounded-md border border-gray-300">
+                    <div class="inline-flex rounded-md border border-gray-300 dark:border-gray-600">
                         <a href="/api/jobs/{{ job.id }}/download"
-                           class="inline-flex items-center px-3 py-2 bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 rounded-l-md">
+                           class="inline-flex items-center px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 text-sm font-medium hover:bg-gray-200 dark:hover:bg-gray-600 rounded-l-md">
                             SRT
                         </a>
                         <button x-show="speakers.length > 0" @click="showSrtMenu = !showSrtMenu"
-                                class="inline-flex items-center px-1.5 py-2 bg-gray-100 text-gray-700 text-sm hover:bg-gray-200 rounded-r-md border-l border-gray-300">
+                                class="inline-flex items-center px-1.5 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded-r-md border-l border-gray-300 dark:border-gray-600">
                             <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
                         </button>
                     </div>
                     <div x-show="showSrtMenu" x-transition @click.away="showSrtMenu = false"
-                         class="absolute right-0 top-full mt-1 bg-white shadow-lg rounded-lg border py-1 z-50 min-w-[10rem]">
+                         class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 shadow-lg rounded-lg border py-1 z-50 min-w-[10rem]">
                         <template x-for="sp in speakers" :key="sp">
                             <a :href="'/api/jobs/{{ job.id }}/download?speaker=' + encodeURIComponent(sp)"
                                @click="showSrtMenu = false"
-                               class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100">
+                               class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
                                 <span class="inline-block w-2 h-2 rounded-full" :class="getSpeakerColor(sp).dot"></span>
                                 <span x-text="sp"></span>
                             </a>
@@ -171,22 +171,22 @@ window.srtEditor = function () {
                     </div>
                 </div>
                 <div class="relative" x-data="{ showVttMenu: false }">
-                    <div class="inline-flex rounded-md border border-gray-300">
+                    <div class="inline-flex rounded-md border border-gray-300 dark:border-gray-600">
                         <a href="/api/jobs/{{ job.id }}/download-vtt"
-                           class="inline-flex items-center px-3 py-2 bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200 rounded-l-md">
+                           class="inline-flex items-center px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 text-sm font-medium hover:bg-gray-200 dark:hover:bg-gray-600 rounded-l-md">
                             VTT
                         </a>
                         <button x-show="speakers.length > 0" @click="showVttMenu = !showVttMenu"
-                                class="inline-flex items-center px-1.5 py-2 bg-gray-100 text-gray-700 text-sm hover:bg-gray-200 rounded-r-md border-l border-gray-300">
+                                class="inline-flex items-center px-1.5 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded-r-md border-l border-gray-300 dark:border-gray-600">
                             <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
                         </button>
                     </div>
                     <div x-show="showVttMenu" x-transition @click.away="showVttMenu = false"
-                         class="absolute right-0 top-full mt-1 bg-white shadow-lg rounded-lg border py-1 z-50 min-w-[10rem]">
+                         class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 shadow-lg rounded-lg border py-1 z-50 min-w-[10rem]">
                         <template x-for="sp in speakers" :key="sp">
                             <a :href="'/api/jobs/{{ job.id }}/download-vtt?speaker=' + encodeURIComponent(sp)"
                                @click="showVttMenu = false"
-                               class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100">
+                               class="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700">
                                 <span class="inline-block w-2 h-2 rounded-full" :class="getSpeakerColor(sp).dot"></span>
                                 <span x-text="sp"></span>
                             </a>
@@ -197,15 +197,15 @@ window.srtEditor = function () {
         </div>
 
         <!-- Audio player bar -->
-        <div x-show="!loading" class="mt-3 flex flex-nowrap items-center gap-3 bg-white rounded-lg shadow-sm border px-3 py-2">
+        <div x-show="!loading" class="mt-3 flex flex-nowrap items-center gap-3 bg-white dark:bg-gray-800 rounded-lg shadow-sm border px-3 py-2">
             <button @click="togglePlay()"
-                    class="text-gray-600 hover:text-blue-600 transition-colors flex-shrink-0">
+                    class="text-gray-600 dark:text-gray-300 hover:text-blue-600 transition-colors flex-shrink-0">
                 <svg x-show="!isPlaying" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
                 <svg x-show="isPlaying" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
             </button>
-            <span class="text-xs font-mono text-gray-500 whitespace-nowrap flex-shrink-0" x-text="formatTime(currentTime) + ' / ' + formatTime(audioDuration)"></span>
+            <span class="text-xs font-mono text-gray-500 dark:text-gray-400 whitespace-nowrap flex-shrink-0" x-text="formatTime(currentTime) + ' / ' + formatTime(audioDuration)"></span>
             <div class="flex-1 relative h-6 cursor-pointer group" @click="seekAudio($event)">
-                <div class="absolute top-1/2 -translate-y-1/2 w-full h-1.5 bg-gray-200 rounded-full">
+                <div class="absolute top-1/2 -translate-y-1/2 w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full">
                     <div class="h-full bg-blue-500 rounded-full transition-all" :style="'width:' + (audioDuration ? (currentTime/audioDuration*100) : 0) + '%'"></div>
                 </div>
             </div>
@@ -219,23 +219,23 @@ window.srtEditor = function () {
     <!-- Loading -->
     <div x-show="loading" class="text-center py-12">
         <div class="animate-spin h-8 w-8 border-4 border-blue-600 border-t-transparent rounded-full mx-auto"></div>
-        <p class="mt-3 text-sm text-gray-500">{{ t('srt_editor.loading') }}</p>
+        <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">{{ t('srt_editor.loading') }}</p>
     </div>
 
     <!-- Segments -->
     <div x-show="!loading" class="space-y-3">
         <template x-for="(seg, idx) in segments" :key="idx">
-            <div class="bg-white shadow rounded-lg p-4 border-l-4 transition-colors cursor-pointer"
+            <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-4 border-l-4 transition-colors cursor-pointer"
                  :id="'seg-' + idx"
                  @click="if (!$event.target.closest('textarea, input, button, a, label')) playSegment(seg.start, seg.end)"
-                 :class="activeSegmentIdx === idx ? 'border-blue-500 bg-blue-50' : verifiedIndices.includes(idx) ? 'border-yellow-400 bg-yellow-50' : speakerMap[idx] ? getSpeakerColor(speakerMap[idx]).border : 'border-transparent'">
+                 :class="activeSegmentIdx === idx ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30' : verifiedIndices.includes(idx) ? 'border-yellow-400 bg-yellow-50 dark:bg-yellow-900/30' : speakerMap[idx] ? getSpeakerColor(speakerMap[idx]).border : 'border-transparent'">
                 <div class="flex items-center justify-between mb-2">
                     <div class="flex items-center gap-2">
                         <input type="checkbox" :value="idx" x-model.number="selected"
-                               class="h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-                        <span class="text-xs font-mono text-gray-400" x-text="'#' + (idx + 1)"></span>
+                               class="h-3.5 w-3.5 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
+                        <span class="text-xs font-mono text-gray-400 dark:text-gray-500" x-text="'#' + (idx + 1)"></span>
                         <button @click="playSegment(seg.start, seg.end)"
-                                class="text-gray-400 hover:text-blue-600 transition-colors p-0.5"
+                                class="text-gray-400 dark:text-gray-500 hover:text-blue-600 transition-colors p-0.5"
                                 :title="'Play ' + formatTime(seg.start)">
                             <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
                         </button>
@@ -244,19 +244,19 @@ window.srtEditor = function () {
                             <button @click="nudgeTime(idx, 'start', -0.1)" class="text-gray-300 hover:text-gray-600 text-xs px-0.5">−</button>
                             <input type="text" :value="formatTimeFull(seg.start)"
                                    @change="const v = parseTime($event.target.value); if (v !== null) { seg.start = v; debounceSave() } else { $event.target.value = formatTimeFull(seg.start) }"
-                                   class="w-20 text-xs font-mono text-gray-500 bg-transparent border-0 border-b border-dashed border-gray-300 focus:border-blue-500 focus:ring-0 p-0 text-center">
+                                   class="w-20 text-xs font-mono text-gray-500 dark:text-gray-400 bg-transparent border-0 border-b border-dashed border-gray-300 dark:border-gray-600 focus:border-blue-500 focus:ring-0 p-0 text-center">
                             <button @click="nudgeTime(idx, 'start', 0.1)" class="text-gray-300 hover:text-gray-600 text-xs px-0.5">+</button>
                         </div>
-                        <span class="text-xs text-gray-400">→</span>
+                        <span class="text-xs text-gray-400 dark:text-gray-500">→</span>
                         <div class="inline-flex items-center gap-0.5">
                             <button @click="nudgeTime(idx, 'end', -0.1)" class="text-gray-300 hover:text-gray-600 text-xs px-0.5">−</button>
                             <input type="text" :value="formatTimeFull(seg.end)"
                                    @change="updateEnd(idx, $event.target.value)"
-                                   class="w-20 text-xs font-mono text-gray-500 bg-transparent border-0 border-b border-dashed border-gray-300 focus:border-blue-500 focus:ring-0 p-0 text-center">
+                                   class="w-20 text-xs font-mono text-gray-500 dark:text-gray-400 bg-transparent border-0 border-b border-dashed border-gray-300 dark:border-gray-600 focus:border-blue-500 focus:ring-0 p-0 text-center">
                             <button @click="nudgeTime(idx, 'end', 0.1)" class="text-gray-300 hover:text-gray-600 text-xs px-0.5">+</button>
                         </div>
                         <span x-show="verifiedIndices.includes(idx)"
-                              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 cursor-help"
+                              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300 cursor-help"
                               :title="verifyReasons[idx] || ''">
                             {{ t('srt_editor.verified_badge') }}
                         </span>
@@ -279,7 +279,7 @@ window.srtEditor = function () {
                 <div x-show="speakers.length > 0" class="flex items-center gap-2 mb-1">
                     <template x-for="sp in speakers" :key="sp">
                         <label class="inline-flex items-center gap-1 cursor-pointer px-1.5 py-0.5 rounded-full text-xs"
-                               :class="speakerMap[idx] === sp ? getSpeakerColor(sp).bg + ' ' + getSpeakerColor(sp).text + ' font-medium' : 'text-gray-500'">
+                               :class="speakerMap[idx] === sp ? getSpeakerColor(sp).bg + ' ' + getSpeakerColor(sp).text + ' font-medium' : 'text-gray-500 dark:text-gray-400'">
                             <span class="inline-block w-2 h-2 rounded-full" :class="getSpeakerColor(sp).dot"></span>
                             <input type="radio" :name="'speaker-' + idx" :value="sp"
                                    :checked="speakerMap[idx] === sp"
@@ -296,7 +296,7 @@ window.srtEditor = function () {
                 <textarea x-model="seg.text" rows="2"
                           @input="autoResize($event.target); debounceSave()"
                           x-effect="$nextTick(() => autoResize($el))"
-                          class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border resize-none"
+                          class="w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border resize-none"
                           style="min-height: 3rem;"></textarea>
 
                 <!-- Time error -->
@@ -304,7 +304,7 @@ window.srtEditor = function () {
 
                 <!-- Verify reason -->
                 <p x-show="verifiedIndices.includes(idx) && verifyReasons[idx]"
-                   class="mt-1 text-xs text-yellow-700">
+                   class="mt-1 text-xs text-yellow-700 dark:text-yellow-300">
                     <span class="font-medium">{{ t('srt_editor.reason') }}:</span>
                     <span x-text="verifyReasons[idx]"></span>
                 </p>
@@ -318,7 +318,7 @@ window.srtEditor = function () {
                         {{ t('srt_editor.accept') }}
                     </button>
                     <button @click="dismissSuggestion(idx)"
-                            class="text-xs text-gray-400 hover:text-gray-600">✕</button>
+                            class="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300">✕</button>
                 </div>
 
                 <!-- Add segment button (between segments) -->
@@ -337,7 +337,7 @@ window.srtEditor = function () {
     <div x-show="selected.length >= 2" x-transition
          class="fixed bottom-6 left-1/2 -translate-x-1/2 bg-blue-600 text-white px-6 py-3 rounded-lg shadow-lg z-50 flex items-center gap-4">
         <span class="text-sm" x-text="selected.length + ' {{ t('srt_editor.segments_selected') }}'"></span>
-        <button @click="mergeSelected()" class="text-sm px-3 py-1 bg-white text-blue-700 rounded font-medium hover:bg-blue-50">
+        <button @click="mergeSelected()" class="text-sm px-3 py-1 bg-white dark:bg-gray-800 text-blue-700 dark:text-blue-300 rounded font-medium hover:bg-blue-50">
             {{ t('srt_editor.merge') }}
         </button>
         <button @click="selected = []" class="text-sm text-blue-200 hover:text-white">{{ t('srt_editor.cancel') }}</button>
@@ -345,25 +345,25 @@ window.srtEditor = function () {
 
     <!-- Back link -->
     <div class="mt-6">
-        <a href="/history" class="text-sm text-gray-500 hover:text-gray-700">← {{ t('srt_editor.back_to_history') }}</a>
+        <a href="/history" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">← {{ t('srt_editor.back_to_history') }}</a>
     </div>
 
     <!-- Keyboard shortcuts help modal -->
     <div x-show="_helpVisible" x-transition @click.self="_helpVisible = false" @keydown.escape.window="_helpVisible = false"
          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
          role="dialog" aria-modal="true" aria-labelledby="srt-shortcuts-title" x-cloak>
-        <div class="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6" @click.stop>
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl max-w-md w-full mx-4 p-6" @click.stop>
             <div class="flex items-center justify-between mb-4">
-                <h3 id="srt-shortcuts-title" class="text-lg font-semibold text-gray-900">{{ t('srt_editor.shortcuts_title') }}</h3>
+                <h3 id="srt-shortcuts-title" class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ t('srt_editor.shortcuts_title') }}</h3>
                 <button @click="_helpVisible = false"
-                        class="text-gray-400 hover:text-gray-600 text-xl"
+                        class="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-xl"
                         aria-label="{{ t('srt_editor.cancel') }}">&times;</button>
             </div>
             <div class="space-y-1.5">
                 <template x-for="s in getShortcutList()" :key="s.keys">
                     <div class="flex items-center justify-between py-1">
-                        <span class="text-sm text-gray-600" x-text="s.desc"></span>
-                        <kbd class="inline-flex items-center px-2 py-0.5 bg-gray-100 border border-gray-200 rounded text-xs font-mono text-gray-700" x-text="s.keys"></kbd>
+                        <span class="text-sm text-gray-600 dark:text-gray-300" x-text="s.desc"></span>
+                        <kbd class="inline-flex items-center px-2 py-0.5 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded text-xs font-mono text-gray-700 dark:text-gray-200" x-text="s.keys"></kbd>
                     </div>
                 </template>
             </div>
@@ -373,7 +373,7 @@ window.srtEditor = function () {
     <!-- Keyboard shortcut hint -->
     <div class="fixed bottom-6 right-6 z-40" x-show="!_helpVisible">
         <button @click="_helpVisible = true"
-                class="w-8 h-8 bg-gray-200 hover:bg-gray-300 text-gray-600 rounded-full shadow text-sm font-bold"
+                class="w-8 h-8 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 text-gray-600 dark:text-gray-300 rounded-full shadow text-sm font-bold"
                 aria-label="{{ t('srt_editor.shortcuts_title') }}"
                 title="{{ t('srt_editor.shortcuts_title') }}">?</button>
     </div>

--- a/src/templates/upload.html
+++ b/src/templates/upload.html
@@ -5,30 +5,30 @@
      data-i18n-starting="{{ t('upload.starting') }}"
      data-i18n-elapsed="{{ t('upload.elapsed') }}"
      data-i18n-upload-failed="{{ t('upload.upload_failed') }}">
-    <h1 class="text-2xl font-bold text-gray-900 mb-6">{{ t('upload.title') }}</h1>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">{{ t('upload.title') }}</h1>
 
     <!-- Upload Form (hidden during processing) -->
-    <form x-show="!jobId" @submit.prevent="submitForm" class="space-y-6 bg-white shadow rounded-lg p-6">
+    <form x-show="!jobId" @submit.prevent="submitForm" class="space-y-6 bg-white dark:bg-gray-800 shadow rounded-lg p-6">
         <!-- File Drop Zone -->
-        <div class="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center"
-             :class="{ 'border-blue-500 bg-blue-50': dragover }"
+        <div class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-8 text-center"
+             :class="{ 'border-blue-500 bg-blue-50 dark:bg-blue-900/30': dragover }"
              @dragover.prevent="dragover = true"
              @dragleave.prevent="dragover = false"
              @drop.prevent="handleDrop($event)">
             <input type="file" accept=".mp4,.mp3,.wav,.mov,.avi,.mkv,.m4a,.flac,.ogg,.webm" @change="handleFile($event)" class="hidden" id="fileInput">
             <div x-show="!file">
-                <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48">
+                <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" stroke="currentColor" fill="none" viewBox="0 0 48 48">
                     <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
-                <p class="mt-2 text-sm text-gray-600">
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
                     <label for="fileInput" class="cursor-pointer text-blue-600 hover:text-blue-500 font-medium">{{ t('upload.click_to_upload') }}</label>
                     {{ t('upload.or_drag_drop') }}
                 </p>
-                <p class="mt-1 text-xs text-gray-500">MP4, MP3, WAV, MOV, AVI, MKV, M4A, FLAC, OGG, WebM</p>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">MP4, MP3, WAV, MOV, AVI, MKV, M4A, FLAC, OGG, WebM</p>
             </div>
-            <div x-show="file" class="text-sm text-gray-700">
+            <div x-show="file" class="text-sm text-gray-700 dark:text-gray-200">
                 <p class="font-medium" x-text="file?.name"></p>
-                <p class="text-gray-500" x-text="formatSize(file?.size)"></p>
+                <p class="text-gray-500 dark:text-gray-400" x-text="formatSize(file?.size)"></p>
                 <button type="button" @click="file = null" class="mt-2 text-red-600 hover:text-red-500 text-xs">{{ t('upload.remove') }}</button>
             </div>
         </div>
@@ -36,15 +36,15 @@
         <!-- Options -->
         <div class="grid grid-cols-2 gap-4">
             <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('upload.provider') }}</label>
-                <select x-model="provider" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('upload.provider') }}</label>
+                <select x-model="provider" class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                     <option value="whisper">OpenAI Whisper</option>
                     <option value="gemini">Google Gemini</option>
                 </select>
             </div>
             <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('upload.language') }}</label>
-                <select x-model="language" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('upload.language') }}</label>
+                <select x-model="language" class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                     <option value="">{{ t('upload.auto_detect') }}</option>
                     <option value="ja">{{ t('upload.lang_ja') }}</option>
                     <option value="en">{{ t('upload.lang_en') }}</option>
@@ -56,36 +56,36 @@
 
         <!-- Post-processing model (shown when refine is enabled) -->
         <div x-show="enableRefine" x-transition>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('upload.refine_model_label') }}</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('upload.refine_model_label') }}</label>
             <div class="grid grid-cols-2 gap-4">
-                <select x-model="ppProvider" @change="onPpProviderChange()" class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border">
+                <select x-model="ppProvider" @change="onPpProviderChange()" class="rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                     <template x-for="p in ppProviders" :key="p.id">
                         <option :value="p.id" x-text="p.label" :disabled="!p.available"></option>
                     </template>
                 </select>
-                <select x-model="selectedModel" class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border min-w-0 truncate">
+                <select x-model="selectedModel" class="rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border min-w-0 truncate dark:bg-gray-800 dark:text-gray-100">
                     <template x-for="m in ppModels" :key="m">
                         <option :value="m" x-text="m"></option>
                     </template>
                 </select>
             </div>
-            <p class="mt-1 text-xs text-gray-500">{{ t('upload.refine_model_hint') }}</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ t('upload.refine_model_hint') }}</p>
         </div>
 
         <!-- Glossary -->
         <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ t('upload.glossary') }}</label>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{{ t('upload.glossary') }}</label>
             <textarea x-model="glossary" rows="3"
                       placeholder="{{ t('upload.glossary_placeholder') }}"
-                      class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border font-mono"></textarea>
-            <p class="mt-1 text-xs text-gray-500">{{ t('upload.glossary_hint') }}</p>
+                      class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border font-mono dark:bg-gray-800 dark:text-gray-100"></textarea>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ t('upload.glossary_hint') }}</p>
         </div>
 
         <!-- Refine -->
         <div class="flex items-center">
             <input type="checkbox" x-model="enableRefine" id="enableRefine"
-                   class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-            <label for="enableRefine" class="ml-2 text-sm text-gray-700">
+                   class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
+            <label for="enableRefine" class="ml-2 text-sm text-gray-700 dark:text-gray-200">
                 {{ t('upload.enable_refine') }}
             </label>
         </div>
@@ -93,9 +93,9 @@
         <!-- Refine Mode -->
         <div x-show="enableRefine" x-transition class="ml-6">
             <div class="flex items-center mb-1">
-                <label class="block text-sm font-medium text-gray-700">{{ t('upload.refine_mode') }}</label>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-200">{{ t('upload.refine_mode') }}</label>
                 <div class="relative inline-block group ml-1">
-                    <span class="cursor-help text-gray-400 hover:text-gray-600 text-sm">?</span>
+                    <span class="cursor-help text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-sm">?</span>
                     <div class="invisible group-hover:visible absolute z-10 w-72 p-3 bg-gray-800 text-white text-xs rounded-lg shadow-lg -top-2 left-6">
                         <p class="mb-2"><span class="font-semibold">Verbatim:</span> {{ t('upload.refine_verbatim_desc') }}</p>
                         <p class="mb-2"><span class="font-semibold">Standard:</span> {{ t('upload.refine_standard_desc') }}</p>
@@ -103,24 +103,24 @@
                     </div>
                 </div>
             </div>
-            <select x-model="refineMode" class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border">
+            <select x-model="refineMode" class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm p-2 border dark:bg-gray-800 dark:text-gray-100">
                 <option value="verbatim">{{ t('upload.refine_verbatim') }}</option>
                 <option value="standard">{{ t('upload.refine_standard') }}</option>
                 <option value="caption">{{ t('upload.refine_caption') }}</option>
             </select>
-            <p class="mt-1 text-xs text-gray-500" x-show="refineMode === 'verbatim'">{{ t('upload.refine_verbatim_desc') }}</p>
-            <p class="mt-1 text-xs text-gray-500" x-show="refineMode === 'standard'">{{ t('upload.refine_standard_desc') }}</p>
-            <p class="mt-1 text-xs text-gray-500" x-show="refineMode === 'caption'">{{ t('upload.refine_caption_desc') }}</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400" x-show="refineMode === 'verbatim'">{{ t('upload.refine_verbatim_desc') }}</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400" x-show="refineMode === 'standard'">{{ t('upload.refine_standard_desc') }}</p>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400" x-show="refineMode === 'caption'">{{ t('upload.refine_caption_desc') }}</p>
 
             <!-- Verify -->
             <div class="flex items-center mt-3">
                 <input type="checkbox" x-model="enableVerify" id="enableVerify"
-                       class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500">
-                <label for="enableVerify" class="ml-2 text-sm text-gray-700">
+                       class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
+                <label for="enableVerify" class="ml-2 text-sm text-gray-700 dark:text-gray-200">
                     {{ t('upload.enable_verify') }}
                 </label>
                 <div class="relative inline-block group ml-1">
-                    <span class="cursor-help text-gray-400 hover:text-gray-600 text-sm">?</span>
+                    <span class="cursor-help text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-sm">?</span>
                     <div class="invisible group-hover:visible absolute z-10 w-64 p-3 bg-gray-800 text-white text-xs rounded-lg shadow-lg -top-2 left-6">
                         {{ t('upload.enable_verify_desc') }}
                     </div>
@@ -138,18 +138,18 @@
     </form>
 
     <!-- Processing Status -->
-    <div x-show="jobId" class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-medium text-gray-900 mb-3">{{ t('upload.processing') }}</h2>
-        <p class="text-sm text-gray-500 mb-3" x-text="fileName"></p>
+    <div x-show="jobId" class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-3">{{ t('upload.processing') }}</h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-3" x-text="fileName"></p>
 
         <!-- Status badge -->
         <div id="job-status" x-html="statusHtml">
             <div class="flex items-center space-x-2">
                 <div class="animate-spin h-4 w-4 border-2 border-blue-600 border-t-transparent rounded-full"></div>
-                <span class="text-sm text-gray-600" x-text="$root.dataset.i18nStarting"></span>
+                <span class="text-sm text-gray-600 dark:text-gray-300" x-text="$root.dataset.i18nStarting"></span>
             </div>
         </div>
-        <p x-show="elapsed > 0" class="mt-2 text-xs text-gray-400" x-text="$root.dataset.i18nElapsed + ' ' + elapsed + 's'"></p>
+        <p x-show="elapsed > 0" class="mt-2 text-xs text-gray-400 dark:text-gray-500" x-text="$root.dataset.i18nElapsed + ' ' + elapsed + 's'"></p>
 
         <!-- Completion links -->
         <div x-show="completedJobId" class="mt-4 flex items-center gap-3">
@@ -158,7 +158,7 @@
                 {{ t('upload.open_editor') }}
             </a>
             <a href="/history"
-               class="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-700 rounded-md text-sm font-medium hover:bg-gray-200 border border-gray-300">
+               class="inline-flex items-center px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 rounded-md text-sm font-medium hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600">
                 {{ t('upload.go_to_history') }}
             </a>
         </div>


### PR DESCRIPTION
Closes #22

## Summary
- Adds class-based dark mode using Tailwind Play CDN's `darkMode: 'class'` strategy — no build step, conforms to `.claude/rules/frontend-stack.md`
- Sun/moon toggle in the nav bar; preference persists in `localStorage` and respects `prefers-color-scheme` on first visit
- Pre-paint theme sync (synchronous IIFE in `<head>`) prevents flash of light content
- `dark:` variants applied across all 8 templates (~400 utility classes)
- Form inputs (`<input>`, `<textarea>`, `<select>`) explicitly get `dark:bg-gray-800` + `dark:text-gray-100` so they remain readable in dark mode
- Body switched from `h-full` to `min-h-screen` so the dark background extends past the viewport on long pages (e.g. settings)

## Implementation notes
- `tailwind.config = { darkMode: 'class' }` is set **both** before and after the CDN script. The Play CDN replaces `window.tailwind` on load in some builds, so the post-load assignment is the reliable one — but the pre-load assignment avoids a brief moment where `dark:` variants compile under `prefers-color-scheme` instead of `.dark`.
- Theme toggle is a plain `onclick="toggleTheme()"` (global function defined in the head script), not Alpine — there's no shared state to manage.

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] `pytest` 199 passed
- [x] Manual: toggle works on /, /history, /costs, /settings, /meta/{id}, /srt-editor/{id}, /setup
- [x] Manual: form inputs (settings, meta editor, srt editor) readable in dark mode
- [x] Manual: long pages (settings) keep dark background when scrolled
- [x] Manual: preference persists across reloads
- [x] No FOUC on initial paint when localStorage = dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)