### PR TITLE
feat(audio): silence-aware chunk boundary splitting

### DIFF
--- a/src/services/audio.py
+++ b/src/services/audio.py
@@ -118,8 +118,13 @@ async def find_all_silences(audio_path: Path) -> list[tuple[float, float]]:
     Returns list of (start, end) silence ranges, or empty list if detection
     fails — callers fall back to fixed-length cuts.
     """
+    # -nostats / -hide_banner suppress per-frame progress output so stderr
+    # only contains silencedetect lines (plus a small banner). Without these,
+    # `communicate()` would buffer megabytes of progress text for long files.
     proc = await asyncio.create_subprocess_exec(
         "ffmpeg",
+        "-nostats",
+        "-hide_banner",
         "-i",
         str(audio_path),
         "-af",
@@ -186,6 +191,14 @@ async def split_audio(audio_path: Path, chunk_duration_sec: int | None = None) -
 
     silences = await find_all_silences(audio_path)
     boundaries = _compute_chunk_boundaries(duration, float(chunk_duration_sec), silences)
+
+    # If boundary computation rejected every internal split point (e.g. the
+    # only target was within _MIN_CHUNK_SEC of the end), boundaries collapses
+    # to [0.0, total_duration]. Return the original path so the caller's
+    # `len(chunks) == 1` short-circuit avoids a redundant ffmpeg invocation
+    # and a leftover _chunk000 file.
+    if len(boundaries) == 2:
+        return [audio_path]
 
     chunks = []
     for idx in range(len(boundaries) - 1):

--- a/tests/test_audio_split.py
+++ b/tests/test_audio_split.py
@@ -83,6 +83,24 @@ async def test_split_audio_short_circuits_when_under_chunk_size():
 
 
 @pytest.mark.asyncio
+async def test_split_audio_short_circuits_when_only_tail_remains():
+    """Audio just slightly longer than chunk_duration → boundary computation
+    rejects the only target as too-close-to-end. split_audio must return the
+    original path instead of creating a single redundant chunk file.
+    """
+    audio = Path("/tmp/borderline.wav")
+    # 600.5s with chunk_duration=600 → boundaries collapse to [0.0, 600.5]
+    with (
+        patch("src.services.audio.get_audio_duration", new=AsyncMock(return_value=600.5)),
+        patch("src.services.audio.find_all_silences", new=AsyncMock(return_value=[])),
+        patch("src.services.audio._run_ffmpeg", new=AsyncMock(return_value=b"")) as mock_ffmpeg,
+    ):
+        result = await split_audio(audio, chunk_duration_sec=600)
+    assert result == [audio]
+    assert mock_ffmpeg.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_split_audio_creates_chunks_at_boundaries(tmp_path):
     """split_audio invokes ffmpeg once per chunk with -ss / -t / -c copy."""
     audio = tmp_path / "long.wav"


### PR DESCRIPTION
## Summary
- Snap chunk boundaries to natural silences instead of cutting at fixed intervals, preventing word truncation at chunk seams
- Run `ffmpeg silencedetect` **once over the full file** via `find_all_silences()`, then compute boundaries in pure Python — no per-target subprocess calls
- Each target boundary at `N * chunk_duration_sec` is snapped to the nearest silence midpoint within ±15s, falling back to the fixed-length boundary when no silence is in range
- Reject anchors that would create chunks shorter than `_MIN_CHUNK_SEC` on either side; short-circuit to the original path when boundary computation collapses to `[0.0, total_duration]`
- Use `-ss` before `-i` and `-c copy` for chunk cuts (~5-10x faster, no re-encoding since chunks come from already-decoded WAV/MP3)
- 11 unit tests covering the parser, boundary computation, and `split_audio` integration with mocked ffmpeg

## Why
Current `split_audio` (`src/services/audio.py`) cuts audio at fixed `whisper_chunk_duration_sec` intervals with no silence detection. Words spanning a boundary can be truncated in both adjacent chunks. This becomes more visible once chunks stream to the editor (#50), so silence anchoring lands first.

## Test plan
- [x] `pytest tests/test_audio_split.py` — 11 passing (parser, boundary computation, integration, tail-edge case)
- [x] `pytest --ignore=tests/e2e` — no regressions
- [x] `ruff check` / `ruff format --check` clean
- [x] Copilot review feedback addressed (3 comments)
- [ ] Manual verification with a 30-min Japanese audio sample

## Commits
- `b756124` initial implementation
- `0026fce` /simplify refactor: single-pass silence detection + faster chunk cuts
- `7113ccc` Copilot review: short-circuit collapsed boundaries, suppress ffmpeg progress noise, add tail-edge regression test

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)