### PR TITLE
fix(api): tolerate undecryptable rows in /api/settings/keys

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import UTC, datetime
 
+from cryptography.fernet import InvalidToken
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -62,11 +63,13 @@ async def list_keys(session: AsyncSession = Depends(get_session)):
         }
         try:
             entry["masked"] = _mask_key(decrypt(k.value))
-        except Exception as e:
-            # Decryption typically fails when ENCRYPTION_KEY has been rotated
-            # since this row was written. Surface the row in an error state
-            # so the UI can prompt re-entry, instead of crashing the whole
-            # endpoint and blanking the settings page.
+        except InvalidToken as e:
+            # Row was encrypted with a different ENCRYPTION_KEY (rotation, DB
+            # restore from another env). Surface in an error state so the UI
+            # can prompt re-entry instead of crashing the whole endpoint.
+            # NOTE: only InvalidToken is swallowed — config errors like a
+            # missing ENCRYPTION_KEY raise RuntimeError from crypto.py and
+            # must propagate so they aren't silently masked.
             logger.warning("Failed to decrypt %s: %s", k.key, e)
             entry["masked"] = "****"
             entry["decryption_error"] = True

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -15,13 +15,24 @@ async def test_list_keys_tolerates_undecryptable_row(make_client):
     The endpoint should surface them with `decryption_error: True` instead of
     returning HTTP 500.
     """
-    # Insert a row with raw bytes that are NOT a valid Fernet token.
-    # Use delete-then-insert in case a previous test left a google row behind.
+    # Generate a syntactically valid Fernet token using a *different* key,
+    # so the row decodes structurally but fails signature verification under
+    # the active ENCRYPTION_KEY — exactly the post-rotation scenario.
+    from cryptography.fernet import Fernet
     from sqlalchemy import delete
 
+    from src.services.crypto import encrypt
+
+    foreign_key = Fernet.generate_key()
+    foreign_token = Fernet(foreign_key).encrypt(b"sk-foreign").decode()
+
+    # Re-seed openai with a fresh, valid token under the active key — the
+    # shared dev DB may carry a stale row left by a different ENCRYPTION_KEY.
     async with async_session() as s:
+        await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
         await s.execute(delete(Setting).where(Setting.key == "api_key.google"))
-        s.add(Setting(key="api_key.google", value="not-a-valid-fernet-token", encrypted=True))
+        s.add(Setting(key="api_key.openai", value=encrypt("sk-test"), encrypted=True))
+        s.add(Setting(key="api_key.google", value=foreign_token, encrypted=True))
         await s.commit()
 
     try:
@@ -38,10 +49,9 @@ async def test_list_keys_tolerates_undecryptable_row(make_client):
         assert openai_entry is not None
         assert openai_entry.get("decryption_error") is not True
     finally:
-        # Cleanup so other tests aren't affected
+        # Cleanup so other tests aren't affected. Leave openai re-seeded with
+        # the valid test token (the autouse fixture relies on its presence).
         async with async_session() as s:
-            from sqlalchemy import delete
-
             await s.execute(delete(Setting).where(Setting.key == "api_key.google"))
             await s.commit()
 


### PR DESCRIPTION
## Summary
- Catch decryption failures per row in \`GET /api/settings/keys\` instead of letting a single \`InvalidToken\` raise out of the endpoint and return HTTP 500
- Surface broken rows with \`decryption_error: true\` + a masked placeholder so the UI can prompt re-entry
- Add a unit test that seeds an undecryptable row and asserts the endpoint stays 200 with the failed row flagged

## Why
Discovered while debugging: the dev server's Settings page rendered blank because \`/api/settings/keys\` returned 500. Root cause was a stale \`api_key.openai\` row that had been encrypted with a different \`ENCRYPTION_KEY\` and could no longer be decrypted (likely from a previous \`.env\` rotation).

The previous code:
\`\`\`python
return [{"masked": _mask_key(decrypt(k.value)), ...} for k in keys]
\`\`\`
A single \`Fernet.InvalidToken\` would raise out of the comprehension → 500 → entire Settings page unusable.

This is also the most likely root cause of the misleading "Model not found. Check Settings → LLM Models." error users see when an \`api_key.*\` row is undecryptable: \`_get_credential\` raises, the heuristic in \`errors.py:131-137\` mismatches, and the user gets a wrong direction.

## Test plan
- [x] \`pytest tests/test_settings_api.py\` — 16 passing, including new \`test_list_keys_tolerates_undecryptable_row\`
- [x] \`pytest --ignore=tests/e2e\` — 202 passing, no regressions
- [x] \`ruff check\` / \`ruff format --check\` clean
- [ ] Manual verification: restart dev container, hit \`/settings\`, confirm the page renders even with the stale row present

## Follow-up
- The misleading error translation in \`src/errors.py:131-137\` should still be addressed separately. See the v1.0.0 robustness Issues to be filed (LLM model validation + raw error preservation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)