### PR TITLE
feat(ui): redesign error_detail panel as inline diagnostic console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ data/assets/
 .pytest_cache/
 htmlcov/
 .coverage
+
+.playwright-mcp/

--- a/src/templates/partials/job_status.html
+++ b/src/templates/partials/job_status.html
@@ -41,7 +41,7 @@
                 <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-red-100 dark:bg-red-900/40"></span>
                 <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-yellow-100 dark:bg-yellow-900/40"></span>
                 <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-green-100 dark:bg-green-900/40"></span>
-                <span class="ml-2 text-xs font-mono text-gray-500 dark:text-gray-400 truncate">~/jobs/{{ detail.stage or 'pipeline' }} — exception</span>
+                <span class="ml-2 flex-1 min-w-0 text-xs font-mono text-gray-500 dark:text-gray-400 truncate">~/jobs/{{ detail.stage or 'pipeline' }} — exception</span>
             </div>
             <dl class="px-3 py-2.5 space-y-1 font-mono text-xs leading-relaxed">
                 <div class="flex gap-3">
@@ -76,7 +76,7 @@
             {% if detail.raw_message %}
             <div class="flex items-start gap-2 rounded-b-md border-t border-gray-300 dark:border-gray-700 px-3 py-2 bg-gray-200 dark:bg-gray-900 font-mono text-xs leading-relaxed text-gray-800 dark:text-gray-200">
                 <span class="text-gray-500 dark:text-gray-400 select-none flex-shrink-0">▶</span>
-                <span class="flex-1 whitespace-pre-wrap break-words">{{ detail.raw_message }}</span>
+                <span class="flex-1 min-w-0 whitespace-pre-wrap break-words">{{ detail.raw_message }}</span>
             </div>
             {% endif %}
         </div>

--- a/src/templates/partials/job_status.html
+++ b/src/templates/partials/job_status.html
@@ -31,17 +31,54 @@
     </p>
     {% endif %}
     {% if detail %}
+    {% set short_exc = detail.exception_class.rsplit('.', 1)[-1] if detail.exception_class else '' %}
     <details class="mt-2">
         <summary class="text-xs cursor-pointer {{ 'text-yellow-700 dark:text-yellow-300' if is_warning else 'text-red-700 dark:text-red-300' }} rounded-sm hover:underline focus:outline-none focus:ring-1 focus:ring-blue-500">
-            {{ t('history.show_details') if t is defined else 'Show details' }}
+            {{ t('history.show_details') if t is defined else 'Show details' }}{% if short_exc %} <span class="font-mono text-gray-500 dark:text-gray-400">— {{ short_exc }}</span>{% endif %}
         </summary>
-        <div class="mt-2 p-2 bg-gray-100 dark:bg-gray-800 rounded font-mono text-xs leading-relaxed text-gray-800 dark:text-gray-200 whitespace-pre-wrap break-all">
-            <div><span class="text-gray-500 dark:text-gray-400">exception:</span> {{ detail.exception_class }}</div>
-            {% if detail.stage %}<div><span class="text-gray-500 dark:text-gray-400">stage:</span> {{ detail.stage }}</div>{% endif %}
-            {% if detail.provider %}<div><span class="text-gray-500 dark:text-gray-400">provider:</span> {{ detail.provider }}</div>{% endif %}
-            {% if detail.model %}<div><span class="text-gray-500 dark:text-gray-400">model:</span> {{ detail.model }}</div>{% endif %}
-            {% if detail.occurred_at %}<div><span class="text-gray-500 dark:text-gray-400">at:</span> {{ detail.occurred_at }}</div>{% endif %}
-            {% if detail.raw_message %}<div class="mt-1 pt-1 border-t border-current/20"><span class="text-gray-500 dark:text-gray-400">raw:</span> {{ detail.raw_message }}</div>{% endif %}
+        <div class="mt-2 rounded-md border border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800">
+            <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-t-md border-b border-gray-300 dark:border-gray-700 bg-gray-200 dark:bg-gray-900">
+                <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-red-100 dark:bg-red-900/40"></span>
+                <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-yellow-100 dark:bg-yellow-900/40"></span>
+                <span class="inline-block w-2 h-2 rounded-full flex-shrink-0 bg-green-100 dark:bg-green-900/40"></span>
+                <span class="ml-2 text-xs font-mono text-gray-500 dark:text-gray-400 truncate">~/jobs/{{ detail.stage or 'pipeline' }} — exception</span>
+            </div>
+            <dl class="px-3 py-2.5 space-y-1 font-mono text-xs leading-relaxed">
+                <div class="flex gap-3">
+                    <dt class="w-20 text-right text-gray-500 dark:text-gray-400 flex-shrink-0">exception</dt>
+                    <dd class="flex-1 text-gray-800 dark:text-gray-200 break-all">{{ detail.exception_class }}</dd>
+                </div>
+                {% if detail.stage %}
+                <div class="flex gap-3">
+                    <dt class="w-20 text-right text-gray-500 dark:text-gray-400 flex-shrink-0">stage</dt>
+                    <dd class="flex-1 text-gray-800 dark:text-gray-200">{{ detail.stage }}</dd>
+                </div>
+                {% endif %}
+                {% if detail.provider %}
+                <div class="flex gap-3">
+                    <dt class="w-20 text-right text-gray-500 dark:text-gray-400 flex-shrink-0">provider</dt>
+                    <dd class="flex-1 text-gray-800 dark:text-gray-200">{{ detail.provider }}</dd>
+                </div>
+                {% endif %}
+                {% if detail.model %}
+                <div class="flex gap-3">
+                    <dt class="w-20 text-right text-gray-500 dark:text-gray-400 flex-shrink-0">model</dt>
+                    <dd class="flex-1 text-gray-800 dark:text-gray-200">{{ detail.model }}</dd>
+                </div>
+                {% endif %}
+                {% if detail.occurred_at %}
+                <div class="flex gap-3">
+                    <dt class="w-20 text-right text-gray-500 dark:text-gray-400 flex-shrink-0">at</dt>
+                    <dd class="flex-1 text-gray-700 dark:text-gray-300">{{ detail.occurred_at }}</dd>
+                </div>
+                {% endif %}
+            </dl>
+            {% if detail.raw_message %}
+            <div class="flex items-start gap-2 rounded-b-md border-t border-gray-300 dark:border-gray-700 px-3 py-2 bg-gray-200 dark:bg-gray-900 font-mono text-xs leading-relaxed text-gray-800 dark:text-gray-200">
+                <span class="text-gray-500 dark:text-gray-400 select-none flex-shrink-0">▶</span>
+                <span class="flex-1 whitespace-pre-wrap break-words">{{ detail.raw_message }}</span>
+            </div>
+            {% endif %}
         </div>
     </details>
     {% endif %}


### PR DESCRIPTION
Closes #58.

## Summary

Restructures the failed/warning job error_detail disclosure into a diagnostic-console surface: title bar with traffic-light dots and pseudo-path, `<dl>` metadata grid, and a console-style raw_message block prefixed with `▶`. The summary line now peeks the exception class (e.g. `Show details — NotFoundError`) so users can triage without expanding.

This is the **scoped-down** version of #58 per a CDO design review. The original issue proposal introduced 5 brand-new design tokens that had **zero prior usage** in the repo:

| Original #58 token | Status here |
|---|---|
| `focus-visible:` | dropped — kept existing `focus:ring-1 focus:ring-blue-500` |
| `backdrop-blur-sm` | dropped — decorative-only |
| `tracking-widest` + `uppercase` | dropped — doesn't translate to JA |
| `bg-{red,amber}-950/30` | dropped — replaced with `bg-gray-200 dark:bg-gray-900` |
| Dynamic `text-{{ ring }}-*` interpolation | dropped — would silently no-op under Tailwind CDN JIT |

Every visual move in #58 is preserved using **only tokens that already exist elsewhere in `src/templates/`**:

- `bg-gray-{100,200}` / `dark:bg-gray-{800,900}` for the surface bands
- `bg-{red,yellow,green}-100` / `dark:bg-{...}-900/40` for the three traffic dots — reuses the exact alert pill colors from `status_colors` at the top of the same file
- `flex` + `w-20` + `flex-1` row layout instead of arbitrary `grid-cols-[max-content_1fr]`
- `border-gray-300 dark:border-gray-700` for borders (82 prior occurrences)

The diagnostic panel is hardcoded to neutral grays regardless of `is_warning` — the parent alert already conveys severity, so the panel reads as a calm inspection chamber inside the colored alert band rather than repeating the signal.

## Why scoped-down

The original issue proposal was written for a Next.js + CVA + component-library stack, not a Jinja + Tailwind-CDN stack. Forcing the dynamic-class-interpolation pattern through here would either silently no-op most styles (because the CDN JIT only sees literal source strings), or require building a parallel `panel_colors` precompute dict for one component. Neither outcome is worth the cost.

Token discipline matters: a polish PR that introduces new tokens has to *earn* them, and #57's review (4de4b89) already caught this exact smuggling pattern once. The 70% scoped version delivers the visual delight with zero new token cost.

## Files changed

- `src/templates/partials/job_status.html` (+38, -8) — the redesign
- `.gitignore` (+2) — added `.playwright-mcp/` so visual-verification screenshots stay out of the working tree

## Test plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 56 files already formatted
- [x] `pytest -m "not e2e"` — 228 passed, 6 deselected, 0 failures, 1.87s
- [x] **Visual verification** in light/dark × en/ja with synthetic failed + completed-warning jobs (isolated `DATA_DIR`, separate alembic.ini, never touched the docker bind-mount DB)
- [x] **`getComputedStyle` checks** on every key element (panel, title bar, traffic dots, dl labels, focus ring, console block) — Tailwind CDN sometimes silently no-ops on classes it doesn't see in source, so per-element computed-style verification is the only reliable test. **Caught and fixed** a `flex-shrink` bug on the traffic dots (5.72px instead of 8px) that snapshot tests would have missed.
- [x] **Re-verified** after `/simplify` collapsed a redundant wrapper div in the console block

## Visual diff

Verification screenshots (4 modes × 2 job states + post-merge re-verify) live in `.playwright-mcp/` which is now gitignored. They are not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)