### PR TITLE
fix(service): keep metadata generation aligned with SRT and JSON contract

### DIFF
--- a/src/api/jobs.py
+++ b/src/api/jobs.py
@@ -540,6 +540,10 @@ async def _generate_meta_job(
         provider_name = get_provider_name(provider)
         try:
             job.status = STATUS_GENERATING_METADATA
+            # Clear any stale error state from a previous failed run so the UI
+            # does not surface old errors after a successful retry.
+            job.error_message = None
+            job.error_detail = None
             await session.commit()
             await status_manager.publish(job_id, STATUS_GENERATING_METADATA)
 

--- a/src/services/metadata.py
+++ b/src/services/metadata.py
@@ -3,8 +3,30 @@ from src.services.utils import create_openai_compatible_client, extract_gemini_t
 
 METADATA_SYSTEM_PROMPT = (
     "You are an expert at generating YouTube video metadata. "
-    "Generate optimal metadata for YouTube from the given video transcription."
+    "Generate optimal metadata for YouTube from the given video transcription. "
+    "Always respond with a valid JSON object."
 )
+
+# Appended after any custom_prompt to guarantee the response is parseable.
+# Custom prompts may specify their own (non-JSON) output format; this overrides it
+# at the boundary so downstream code always finds the expected English keys.
+METADATA_JSON_SCHEMA_REMINDER = """
+
+---
+
+CRITICAL OUTPUT FORMAT — this overrides any other output format mentioned above.
+Return ONLY a single JSON object with these exact English keys (no markdown, no commentary):
+{
+  "titles": ["title candidate 1", "title candidate 2", ...],
+  "description": "full description text (include chapter index inside if applicable)",
+  "tags": ["tag1", "tag2", ...],
+  "chapters": [{"time": "MM:SS", "title": "chapter title"}, ...]
+}
+
+Rules:
+- "titles" is always an array of strings (use a one-element array if there is only one title).
+- Keys MUST be exactly: titles, description, tags, chapters (English, lowercase).
+- Do not wrap the JSON in markdown fences. Do not add any text outside the JSON object."""
 
 METADATA_USER_PROMPT = """Generate YouTube metadata from the following video transcription (SRT format).
 
@@ -67,7 +89,9 @@ async def generate_youtube_metadata(
         )
 
     if custom_prompt:
-        prompt = custom_prompt + tone_section + f"\n\n---\n\nTranscription:\n{srt_content}"
+        prompt = (
+            custom_prompt + tone_section + f"\n\n---\n\nTranscription:\n{srt_content}" + METADATA_JSON_SCHEMA_REMINDER
+        )
     else:
         if tone_section:
             # Insert tone section before the transcription divider
@@ -92,12 +116,30 @@ Make the prompt more specific and effective for generating:
 - Engaging descriptions (with chapter index format)
 - Relevant tags
 
-Channel context:
+CRITICAL — the prompt you produce is a REUSABLE TEMPLATE applied to MANY future
+videos that you have not seen. Therefore:
+- DO NOT embed specific chapter timestamps, episode titles, dialogue excerpts,
+  topic summaries, or one-off guest names taken from the channel notes or tone
+  reference. Those are samples for style only, not facts about every video.
+- The optimized prompt MUST instruct the model to derive video-specific content
+  (theme, chapters, summary, per-episode guests) from the actual transcription
+  given at runtime — never from hardcoded values inside the prompt itself.
+- Only channel-level facts that are true for EVERY video on the channel
+  (channel name, genre, regular host(s), target audience, overall mission) may
+  appear as fixed context.
+
+The improved prompt MUST preserve a JSON output format specification with these
+exact English keys so the response remains parseable downstream:
+"titles" (array of strings), "description" (string), "tags" (array of strings),
+"chapters" (array of {{"time": "MM:SS", "title": string}}).
+
+Channel context (channel-level only; do not bake video-specific data into the prompt):
 - Channel: {channel_name}
 - Genre: {genre}
-- Speakers: {speakers}
+- Regular speakers: {speakers}
 - Target audience: {audience}
-- Notes: {notes}
+- Notes (channel description / sample tone — DO NOT copy specific chapters or \
+episode details from here into the optimized prompt): {notes}
 {tone_ref_section}
 Current prompt:
 {current_prompt}

--- a/src/services/refine.py
+++ b/src/services/refine.py
@@ -9,7 +9,8 @@ logger = logging.getLogger(__name__)
 
 REFINE_SYSTEM_PROMPT = (
     "You are a professional subtitle editor. "
-    "Your job is to correct transcription errors while preserving timestamps exactly as given."
+    "Your job is to correct transcription errors while preserving timestamps exactly as given. "
+    "Always respond with a valid JSON object."
 )
 
 # --- Verbatim mode: minimal corrections only ---
@@ -224,7 +225,8 @@ async def _refine_gemini(prompt: str, api_key: str, model: str) -> tuple[list[di
 VERIFY_SYSTEM_PROMPT = (
     "You are a professional proofreader specialising in transcription quality. "
     "You read an entire transcript and find inconsistencies in proper nouns, "
-    "place names, kanji, and terminology."
+    "place names, kanji, and terminology. "
+    "Always respond with a valid JSON object."
 )
 
 VERIFY_PROMPT = """\

--- a/tests/test_llm_services.py
+++ b/tests/test_llm_services.py
@@ -69,6 +69,31 @@ async def test_generate_metadata_with_tone_ref():
 
 
 @pytest.mark.asyncio
+async def test_generate_metadata_custom_prompt_without_json_keyword():
+    """OpenAI requires 'json' in messages when response_format is json_object.
+    A custom prompt that omits the word must still succeed because the system
+    prompt carries the keyword.
+    """
+    from src.services.metadata import generate_youtube_metadata
+
+    response = mock_openai_response('{"title": "T", "description": "d", "tags": [], "chapters": []}')
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=response)
+    mock_openai = MagicMock()
+    mock_openai.AsyncOpenAI.return_value = mock_client
+
+    custom = "Generate YouTube metadata. Title under 60 chars, description, 15-25 tags, chapters."
+    assert "json" not in custom.lower()
+
+    with patch.dict("sys.modules", {"openai": mock_openai}):
+        await generate_youtube_metadata("hi", "fake-key", "openai", "gpt-5.4", custom_prompt=custom)
+
+    messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    combined = " ".join(m["content"] for m in messages).lower()
+    assert "json" in combined, "OpenAI rejects json_object response_format unless 'json' appears in messages"
+
+
+@pytest.mark.asyncio
 async def test_generate_catchphrases_openai():
     from src.services.catchphrase import generate_catchphrases
 


### PR DESCRIPTION
## Summary

メタデータ生成で連鎖していた3つの不具合をまとめて修正。

- **OpenAI 400 (\`'messages' must contain the word 'json'\`)** — \`METADATA_SYSTEM_PROMPT\` に \"JSON\" キーワードを追加し、ユーザーの custom_prompt が JSON を含まなくても \`response_format=json_object\` が通るようにした。同じバグ系統 (\`refine.py\` / \`verify\`) の system prompt にも予防的に \"JSON\" を追加。
- **生成結果が空** — custom_prompt 経由でLLMが日本語キーJSONを返すことがあったため、custom_prompt 末尾に \`METADATA_JSON_SCHEMA_REMINDER\` を注入し、英語キー (\`titles\`/\`description\`/\`tags\`/\`chapters\`) を強制。
- **メタデータがSRTを参照しない** — 「プロンプト最適化」が \`meta_context.notes\` に書かれた特定動画の章/出演者を最適化結果へ焼き込んでいた。\`OPTIMIZE_PROMPT\` を強化し、再利用テンプレートには動画固有値を埋め込まないこと、JSONスキーマを保つことを明示。
- **古いエラーが成功後も残る** — メタデータ再生成開始時に \`job.error_message\` / \`job.error_detail\` をクリアし、成功時に過去の失敗が UI に残らないようにした。

## Test plan

- [x] \`pytest tests/\` 242 passed
- [x] \`ruff check src/ tests/\` clean
- [x] \`ruff format --check\` clean
- [x] 回帰テスト追加: \`test_generate_metadata_custom_prompt_without_json_keyword\` — custom_prompt が \"json\" を含まなくても messages 全体に \"json\" が残ることを検証
- [x] 実機確認 (Docker): SRTの内容に基づいたタイトル候補3件 / 819文字説明 / 22タグが生成され、古いエラー表示も再生成で消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)