### PR TITLE
fix(service): InvalidToken handling + ENCRYPTION_KEY regeneration prevention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
+# ⚠️ WARNING: Do NOT regenerate ENCRYPTION_KEY once set.
+# If you change this key, all stored API keys become permanently unreadable.
 # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ENCRYPTION_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,12 @@ When asked to set up this project, follow these steps:
    ```
 
 2. **Generate encryption key and create .env**
+   If `.env` already exists with `ENCRYPTION_KEY` set, **skip this step** —
+   regenerating the key will corrupt all stored API keys.
    ```bash
-   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+   if [ ! -f .env ] || ! grep -q "^ENCRYPTION_KEY=.+" .env; then
+     python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+   fi
    ```
    Create `.env` file with:
    ```

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import UTC, datetime
 
-from cryptography.fernet import InvalidToken
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -19,7 +18,7 @@ from src.errors import (
     unknown_setting,
 )
 from src.models import Setting
-from src.services.crypto import decrypt, encrypt
+from src.services.crypto import DecryptionError, decrypt_credential, encrypt
 
 logger = logging.getLogger(__name__)
 
@@ -62,15 +61,8 @@ async def list_keys(session: AsyncSession = Depends(get_session)):
             "updated_at": k.updated_at.isoformat() if k.updated_at else None,
         }
         try:
-            entry["masked"] = _mask_key(decrypt(k.value))
-        except InvalidToken as e:
-            # Row was encrypted with a different ENCRYPTION_KEY (rotation, DB
-            # restore from another env). Surface in an error state so the UI
-            # can prompt re-entry instead of crashing the whole endpoint.
-            # NOTE: only InvalidToken is swallowed — config errors like a
-            # missing ENCRYPTION_KEY raise RuntimeError from crypto.py and
-            # must propagate so they aren't silently masked.
-            logger.warning("Failed to decrypt %s: %s", k.key, e)
+            entry["masked"] = _mask_key(decrypt_credential(k.value))
+        except DecryptionError:
             entry["masked"] = "****"
             entry["decryption_error"] = True
         out.append(entry)
@@ -114,7 +106,10 @@ async def test_key(provider: str, session: AsyncSession = Depends(get_session)):
     if not setting:
         raise key_not_configured()
 
-    api_key = decrypt(setting.value)
+    try:
+        api_key = decrypt_credential(setting.value)
+    except DecryptionError:
+        return {"valid": False, "error": "暗号化キーが変更されました。APIキーを再設定してください。"}
 
     try:
         if provider == "openai":

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -63,6 +63,7 @@ async def list_keys(session: AsyncSession = Depends(get_session)):
         try:
             entry["masked"] = _mask_key(decrypt_credential(k.value))
         except DecryptionError:
+            logger.warning("Failed to decrypt %s: encryption key mismatch", k.key)
             entry["masked"] = "****"
             entry["decryption_error"] = True
         out.append(entry)
@@ -109,7 +110,10 @@ async def test_key(provider: str, session: AsyncSession = Depends(get_session)):
     try:
         api_key = decrypt_credential(setting.value)
     except DecryptionError:
-        return {"valid": False, "error": "暗号化キーが変更されました。APIキーを再設定してください。"}
+        return {
+            "valid": False,
+            "error": "Encryption key has changed. Please re-enter your API key in Settings → API Keys.",
+        }
 
     try:
         if provider == "openai":

--- a/src/errors.py
+++ b/src/errors.py
@@ -144,6 +144,10 @@ def unknown_setting(key: str) -> AppError:
 def classify_error(exc: Exception) -> str:
     """Classify an exception into a user-friendly message with actionable hint."""
     msg = str(exc)
+    from src.services.crypto import DecryptionError
+
+    if isinstance(exc, DecryptionError):
+        return str(exc)
     if isinstance(exc, TimeoutError) or "timeout" in msg.lower():
         return "Processing timed out. Try a smaller file or a faster model."
     if "401" in msg or "unauthorized" in msg.lower() or "invalid api key" in msg.lower():

--- a/src/services/crypto.py
+++ b/src/services/crypto.py
@@ -35,4 +35,6 @@ def decrypt_credential(ciphertext: str) -> str:
     try:
         return decrypt(ciphertext)
     except InvalidToken:
-        raise DecryptionError("暗号化キーが変更されました。Settings → API Keys でAPIキーを再設定してください。")
+        raise DecryptionError(
+            "Encryption key has changed. Please re-enter your API key in Settings → API Keys."
+        ) from None

--- a/src/services/crypto.py
+++ b/src/services/crypto.py
@@ -1,6 +1,10 @@
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 
 from src.config import settings
+
+
+class DecryptionError(RuntimeError):
+    """Stored value cannot be decrypted — encryption key was rotated or replaced."""
 
 
 def _get_fernet() -> Fernet:
@@ -19,3 +23,16 @@ def encrypt(plaintext: str) -> str:
 
 def decrypt(ciphertext: str) -> str:
     return _get_fernet().decrypt(ciphertext.encode()).decode()
+
+
+def decrypt_credential(ciphertext: str) -> str:
+    """Decrypt a stored credential.
+
+    Raises DecryptionError if ENCRYPTION_KEY has changed since the value
+    was encrypted, so callers can surface a user-friendly recovery message
+    instead of crashing with a raw InvalidToken.
+    """
+    try:
+        return decrypt(ciphertext)
+    except InvalidToken:
+        raise DecryptionError("暗号化キーが変更されました。Settings → API Keys でAPIキーを再設定してください。")

--- a/src/services/transcribe.py
+++ b/src/services/transcribe.py
@@ -27,7 +27,7 @@ from src.errors import actionable_error, serialize_error_detail
 from src.models import Job, Setting
 from src.services.audio import extract_audio, extract_audio_mp3, get_audio_duration, split_audio
 from src.services.cost import estimate_gemini_cost, estimate_llm_cost, estimate_whisper_cost, log_cost
-from src.services.crypto import decrypt
+from src.services.crypto import decrypt_credential
 from src.services.srt import generate_srt, save_srt
 from src.services.status import status_manager
 
@@ -53,7 +53,7 @@ async def _get_credential(session: AsyncSession, provider: str) -> str:
     setting = result.scalar_one_or_none()
     if not setting:
         raise RuntimeError(f"{provider_label} API key is not configured. Go to Settings → API Keys to add it.")
-    return decrypt(setting.value)
+    return decrypt_credential(setting.value)
 
 
 async def _get_model(session: AsyncSession, provider: str, override: str | None = None) -> str:

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -179,6 +179,32 @@ async def test_set_meta_context(make_client):
 
 
 @pytest.mark.asyncio
+async def test_test_key_decryption_error(make_client):
+    """test_key returns valid=False when ENCRYPTION_KEY has been rotated."""
+    from cryptography.fernet import Fernet
+    from sqlalchemy import delete
+
+    foreign_token = Fernet(Fernet.generate_key()).encrypt(b"sk-foreign").decode()
+
+    async with async_session() as s:
+        await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
+        s.add(Setting(key="api_key.openai", value=foreign_token, encrypted=True))
+        await s.commit()
+
+    try:
+        async with make_client() as c:
+            resp = await c.post("/api/settings/keys/openai/test")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is False
+        assert "Encryption key" in data["error"]
+    finally:
+        async with async_session() as s:
+            await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
+            await s.commit()
+
+
+@pytest.mark.asyncio
 async def test_save_key_invalid_provider(make_client):
     async with make_client() as c:
         resp = await c.put("/api/settings/keys/invalid", json={"key": "test-key"})


### PR DESCRIPTION
## Summary
- Centralize `InvalidToken` handling in `crypto.py` via `decrypt_credential()` helper, preventing `cryptography.fernet` exceptions from leaking across modules
- Wrap `_get_credential()` and `test_key()` decrypt calls — users now get a clear "re-enter API key" message instead of a crash
- Prevent accidental ENCRYPTION_KEY regeneration in setup instructions

## Changes
| File | Change | Purpose |
|---|---|---|
| `src/services/crypto.py` | +18/-1 | New `DecryptionError` + `decrypt_credential()` helper |
| `src/services/transcribe.py` | +2/-2 | `_get_credential()` uses `decrypt_credential()` |
| `src/api/settings.py` | +7/-12 | `list_keys()` + `test_key()` catch `DecryptionError` |
| `CLAUDE.md` | +5/-1 | Guard against key regeneration in setup |
| `.env.example` | +2/-0 | Warning about key overwrite danger |

Closes #66
Closes #69