### PR TITLE
refactor: batch #70, #71

### DIFF
--- a/.claude/rules/encrypted-settings.md
+++ b/.claude/rules/encrypted-settings.md
@@ -1,20 +1,67 @@
 ---
-description: API keys and secrets must be stored encrypted in DB via crypto.py. Never store plaintext secrets.
+description: API keys and secrets must be stored encrypted in DB via EncryptionService. Never store plaintext secrets.
 ---
 
 # Encrypted Settings Rule
 
 ## Pattern
 1. User enters API key in Settings page
-2. Backend encrypts with `crypto.encrypt()` (Fernet) before DB write
-3. On use, decrypt with `crypto.decrypt()` just before API call
+2. Backend encrypts with `EncryptionService.encrypt()` (Fernet) before DB write
+3. On use, `EncryptionService.decrypt_credential()` just before API call
 4. Never log or return decrypted keys in responses
+
+`EncryptionService` lives in `src/services/crypto.py`. Stateless primitives
+(`encrypt`, `decrypt`, `decrypt_credential`, `get_fingerprint`) are
+`@staticmethod`; DB-aware helpers (`get_stored_fingerprint`,
+`all_api_keys_decrypt`, `validate_stored_keys`, `api_key_status`,
+`reencrypt_all`) are instance methods bound to an `AsyncSession` at
+construction. Module-level shims (`encrypt`, `decrypt`,
+`decrypt_credential`, `get_fingerprint`) exist as backward-compatibility
+wrappers — new code should prefer the class form.
+
+## Setting key namespaces
+
+The `Setting` table holds three logical categories distinguished only by
+the key's prefix:
+
+| Prefix | `encrypted` | Examples |
+|---|---|---|
+| `api_key.<provider>` | `True` | `api_key.openai`, `api_key.google` |
+| `_meta.*` (reserved) | `False` | `_meta.encryption_key_fingerprint` |
+| Everything else (model, glossary, pricing, etc.) | `False` | `model.openai`, `glossary`, `pricing`, `general.*` |
+
+`crypto.ENCRYPTED_KEY_PREFIXES` is the **canonical declaration** of which
+prefixes are sensitive. To add a new encrypted-by-default namespace,
+extend `ENCRYPTED_KEY_PREFIXES` — do **not** rely on each call site
+remembering to pass `encrypted=True`.
+
+`_meta.*` is the reserved namespace for app-internal metadata that needs
+to live in the `Setting` table (so we avoid Alembic migrations for
+additive metadata) but is intentionally plaintext: hashes, schema
+versions, and similar identity-check values.
+
+## `_upsert_setting` contract
+
+`src/api/settings.py:_upsert_setting(session, key, value, encrypted=None)`:
+
+- `encrypted=None` (default): the flag is derived from the key prefix
+  against `ENCRYPTED_KEY_PREFIXES`. Callers should normally omit it.
+- `encrypted=True/False` explicit: used as-is, **except** that
+  `encrypted=False` for a key matching `ENCRYPTED_KEY_PREFIXES` raises
+  `ValueError`. The prefix declaration is load-bearing; silently
+  overriding it would defeat the safety net.
 
 ## Key management
 - `ENCRYPTION_KEY` env var is the only secret in `.env`
 - All other secrets go through the Settings → encrypted DB flow
+- The active `ENCRYPTION_KEY` fingerprint is stamped to
+  `_meta.encryption_key_fingerprint` on every successful `save_key` once
+  all existing rows decrypt — rotation detection in `list_keys` reads it
 
 ## When adding new API integrations
 - Store credentials via the existing `Setting` model (key-value, encrypted)
+- Use the `api_key.<provider>` key shape so `ENCRYPTED_KEY_PREFIXES`
+  classifies it automatically
 - Never add new secrets to `.env` or hardcode in source
-- Use `services/crypto.py` — do not create alternative encryption
+- Use `EncryptionService` (or the module-level shims) — do not create
+  alternative encryption

--- a/src/api/pages.py
+++ b/src/api/pages.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.database import get_session
 from src.models import Job
-from src.services.crypto import DecryptionError, decrypt_credential
+from src.services.crypto import EncryptionService
 from src.templating import get_lang, get_translator, templates
 
 router = APIRouter()
@@ -17,43 +17,8 @@ def _i18n_context(request: Request) -> dict:
     return {"t": get_translator(lang), "lang": lang}
 
 
-async def _api_key_status(session: AsyncSession) -> tuple[bool, bool]:
-    """Return (has_decryptable, has_undecryptable) for stored api_key.% rows.
-
-    A row is "undecryptable" when DecryptionError is raised — typically because
-    ENCRYPTION_KEY was changed after the row was written. Both flags surface so
-    callers can distinguish "no keys at all" from "keys exist but the active
-    ENCRYPTION_KEY can't decrypt them" — the latter needs a user-visible warning,
-    not a silent /setup redirect followed by a later crash in _get_credential().
-    """
-    from src.models import Setting
-
-    result = await session.execute(select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True)))
-    has_decryptable = False
-    has_undecryptable = False
-    for row in result.scalars():
-        # Fernet decrypt does signature verification — stop as soon as both
-        # flags are set so request-path callers (landing, upload) don't burn
-        # cycles on every additional row when the answer is already decided.
-        if has_decryptable and has_undecryptable:
-            break
-        try:
-            decrypt_credential(row.value)
-            has_decryptable = True
-        except DecryptionError:
-            has_undecryptable = True
-        # Deliberately *don't* catch RuntimeError here. _get_fernet() raises
-        # RuntimeError when ENCRYPTION_KEY is unset, which is a server
-        # misconfiguration — not a data-state recovery scenario. Letting it
-        # propagate as a 500 fails fast and signals "fix the env var" rather
-        # than misdirecting the user to a "your keys have changed" recovery
-        # banner they cannot actually act on (save_key would also crash for
-        # the same reason).
-    return has_decryptable, has_undecryptable
-
-
 async def _has_api_keys(session: AsyncSession) -> bool:
-    has_decryptable, _ = await _api_key_status(session)
+    has_decryptable, _ = await EncryptionService(session).api_key_status()
     return has_decryptable
 
 
@@ -82,7 +47,7 @@ async def setup_page(request: Request, session: AsyncSession = Depends(get_sessi
     # which is strictly stronger. The /setup banner uses the looser signal
     # so that single-row corruption still surfaces the recovery flow, not
     # just full-key rotation.
-    _, has_undecryptable_keys = await _api_key_status(session)
+    _, has_undecryptable_keys = await EncryptionService(session).api_key_status()
     ctx = {
         "active_page": "settings",
         "has_undecryptable_keys": has_undecryptable_keys,

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -21,6 +21,7 @@ from src.models import Setting
 from src.services.crypto import (
     ENCRYPTION_KEY_FINGERPRINT_SETTING,
     DecryptionError,
+    EncryptionService,
     decrypt_credential,
     encrypt,
     get_fingerprint,
@@ -55,39 +56,6 @@ class GeneralSettingInput(BaseModel):
     value: str
 
 
-async def _get_stored_fingerprint(session: AsyncSession) -> str | None:
-    """Return the ENCRYPTION_KEY fingerprint persisted at the last save_key call.
-
-    None means "never stamped" (legacy / fresh install) — callers must treat
-    None as 'unknown', NOT as 'mismatch', so existing users without a stamped
-    fingerprint don't see a false rotation warning until they next save a key.
-    """
-    result = await session.execute(select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
-    setting = result.scalar_one_or_none()
-    return setting.value if setting else None
-
-
-async def _all_api_keys_decrypt(session: AsyncSession) -> bool:
-    """True iff every encrypted api_key.% row decrypts under the active key.
-
-    Gates the fingerprint stamp in save_key: stamping unconditionally would
-    silently lose the rotation signal during partial recovery. Concretely,
-    if a user has 2 stale rows from a previous ENCRYPTION_KEY and re-saves
-    only one provider, the fingerprint would update to the new key value
-    and list_keys would no longer flag the remaining stale row as
-    key_mismatch — it would still surface decryption_error, but the
-    Settings banner (which keys off key_mismatch) would hide, suggesting
-    "recovery complete" before the second row is fixed.
-    """
-    result = await session.execute(select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True)))
-    for row in result.scalars():
-        try:
-            decrypt_credential(row.value)
-        except DecryptionError:
-            return False
-    return True
-
-
 @router.get("/keys")
 async def list_keys(session: AsyncSession = Depends(get_session)):
     # Scope the query to the api_key.% namespace so the endpoint's contract
@@ -102,7 +70,8 @@ async def list_keys(session: AsyncSession = Depends(get_session)):
     # decrypt loop, so we can distinguish a single corrupted row from a
     # whole-key rotation. A None stored fingerprint stays "unknown" — never
     # surfaced as a mismatch — to keep legacy installs quiet.
-    stored_fp = await _get_stored_fingerprint(session)
+    crypto = EncryptionService(session)
+    stored_fp = await crypto.get_stored_fingerprint()
     key_mismatch = stored_fp is not None and stored_fp != get_fingerprint()
 
     out = []
@@ -145,7 +114,7 @@ async def save_key(provider: str, body: KeyInput, session: AsyncSession = Depend
     # the active key while N-1 rows remain encrypted under the prior key —
     # list_keys would then drop the key_mismatch flag on those rows and the
     # rotation banner would vanish before the recovery is actually complete.
-    if await _all_api_keys_decrypt(session):
+    if await EncryptionService(session).all_api_keys_decrypt():
         await _upsert_setting(session, ENCRYPTION_KEY_FINGERPRINT_SETTING, get_fingerprint())
     await session.commit()
     return {"provider": provider, "configured": True}

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -19,6 +19,7 @@ from src.errors import (
 )
 from src.models import Setting
 from src.services.crypto import (
+    ENCRYPTED_KEY_PREFIXES,
     ENCRYPTION_KEY_FINGERPRINT_SETTING,
     DecryptionError,
     EncryptionService,
@@ -32,8 +33,39 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 
-async def _upsert_setting(session: AsyncSession, key: str, value: str, encrypted: bool = False):
-    """Check if setting exists, update or create it."""
+async def _upsert_setting(
+    session: AsyncSession,
+    key: str,
+    value: str,
+    encrypted: bool | None = None,
+):
+    """Insert or update a Setting row, deriving the encrypted flag from
+    `ENCRYPTED_KEY_PREFIXES` when the caller does not pass one explicitly.
+
+    Auto-classification rules:
+    - `encrypted=None` (default): key matches a prefix in
+      ENCRYPTED_KEY_PREFIXES → True; otherwise → False.
+    - `encrypted=True/False` explicit: used as-is.
+
+    Safety invariant: a key whose prefix is in ENCRYPTED_KEY_PREFIXES
+    cannot be saved with `encrypted=False`. The constant is the *canonical*
+    declaration of which namespaces hold sensitive data; passing a literal
+    False for an api_key.% row would silently store plaintext credentials
+    in the DB. Reject that combination at the contract layer rather than
+    waiting for a future audit to catch it. Plain settings can still use
+    the api_key.% namespace if they truly are non-sensitive (rare) by
+    extending ENCRYPTED_KEY_PREFIXES, not by overriding here.
+    """
+    requires_encryption = any(key.startswith(p) for p in ENCRYPTED_KEY_PREFIXES)
+    if encrypted is None:
+        encrypted = requires_encryption
+    elif requires_encryption and not encrypted:
+        raise ValueError(
+            f"Setting key {key!r} is in ENCRYPTED_KEY_PREFIXES but encrypted=False — "
+            "would store sensitive data in plaintext. Either remove the explicit "
+            "encrypted=False or extend ENCRYPTED_KEY_PREFIXES."
+        )
+
     result = await session.execute(select(Setting).where(Setting.key == key))
     setting = result.scalar_one_or_none()
     if setting:
@@ -105,7 +137,8 @@ async def save_key(provider: str, body: KeyInput, session: AsyncSession = Depend
 
     db_key = f"api_key.{provider}"
     encrypted_value = encrypt(body.key)
-    await _upsert_setting(session, db_key, encrypted_value, encrypted=True)
+    # encrypted flag is auto-derived from "api_key." in ENCRYPTED_KEY_PREFIXES.
+    await _upsert_setting(session, db_key, encrypted_value)
     # Flush the new row so the subsequent decrypt scan can see it.
     await session.flush()
     # Stamp the active ENCRYPTION_KEY fingerprint only when every encrypted

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -47,14 +47,20 @@ async def _upsert_setting(
       ENCRYPTED_KEY_PREFIXES → True; otherwise → False.
     - `encrypted=True/False` explicit: used as-is.
 
-    Safety invariant: a key whose prefix is in ENCRYPTED_KEY_PREFIXES
-    cannot be saved with `encrypted=False`. The constant is the *canonical*
+    Safety invariant: a key whose prefix is in ENCRYPTED_KEY_PREFIXES MUST
+    be saved with `encrypted=True`. The constant is the *canonical*
     declaration of which namespaces hold sensitive data; passing a literal
-    False for an api_key.% row would silently store plaintext credentials
-    in the DB. Reject that combination at the contract layer rather than
-    waiting for a future audit to catch it. Plain settings can still use
-    the api_key.% namespace if they truly are non-sensitive (rare) by
-    extending ENCRYPTED_KEY_PREFIXES, not by overriding here.
+    False for an api_key.% row would silently store plaintext credentials,
+    so the function raises ValueError instead. There is intentionally no
+    opt-out — to add a new sensitive namespace, extend
+    ENCRYPTED_KEY_PREFIXES so every call site classifies it consistently.
+
+    Existing-row sync: when an `api_key.%` row predates the auto-detect
+    contract (legacy state where `encrypted=False` was somehow written),
+    the update branch also overwrites `encrypted` so the row's metadata
+    converges to what the safety invariant requires. Without this, a stale
+    row would stay invisible to list_keys (which filters on encrypted=True)
+    even after the user re-saved their key.
     """
     requires_encryption = any(key.startswith(p) for p in ENCRYPTED_KEY_PREFIXES)
     if encrypted is None:
@@ -70,6 +76,7 @@ async def _upsert_setting(
     setting = result.scalar_one_or_none()
     if setting:
         setting.value = value
+        setting.encrypted = encrypted
         setting.updated_at = datetime.now(UTC)
     else:
         setting = Setting(key=key, value=value, encrypted=encrypted)

--- a/src/services/crypto.py
+++ b/src/services/crypto.py
@@ -106,11 +106,13 @@ class EncryptionService:
         setting = result.scalar_one_or_none()
         return setting.value if setting else None
 
-    async def all_api_keys_decrypt(self) -> bool:
-        """True iff every encrypted api_key.% row decrypts under the active key.
+    async def _iter_encrypted_api_key_rows(self):
+        """Yield every encrypted api_key.% Setting row for the active session.
 
-        Gates the fingerprint stamp in save_key: stamping unconditionally
-        would silently lose the rotation signal during partial recovery.
+        Single source of truth for the SQL filter used by every
+        decrypt-scanning method below — change the predicate here and all
+        scanners adjust, instead of relying on four `Setting.key.like(...)`
+        literals staying in sync.
         """
         from src.models import Setting
 
@@ -118,6 +120,15 @@ class EncryptionService:
             select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
         )
         for row in result.scalars():
+            yield row
+
+    async def all_api_keys_decrypt(self) -> bool:
+        """True iff every encrypted api_key.% row decrypts under the active key.
+
+        Gates the fingerprint stamp in save_key: stamping unconditionally
+        would silently lose the rotation signal during partial recovery.
+        """
+        async for row in self._iter_encrypted_api_key_rows():
             try:
                 EncryptionService.decrypt_credential(row.value)
             except DecryptionError:
@@ -140,14 +151,9 @@ class EncryptionService:
         propagate fails fast and signals "fix the env var" rather than
         misdirecting the user to a recovery banner they cannot act on.
         """
-        from src.models import Setting
-
-        result = await self.session.execute(
-            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
-        )
         has_decryptable = False
         has_undecryptable = False
-        for row in result.scalars():
+        async for row in self._iter_encrypted_api_key_rows():
             # Fernet decrypt does signature verification — stop as soon as
             # both flags are set so request-path callers (landing, upload)
             # don't burn cycles on every additional row when the answer is
@@ -169,13 +175,8 @@ class EncryptionService:
         per-provider status instead of the binary all-or-nothing signal
         that all_api_keys_decrypt returns.
         """
-        from src.models import Setting
-
-        result = await self.session.execute(
-            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
-        )
         status: dict[str, bool] = {}
-        for row in result.scalars():
+        async for row in self._iter_encrypted_api_key_rows():
             try:
                 EncryptionService.decrypt_credential(row.value)
                 status[row.key] = True
@@ -188,26 +189,33 @@ class EncryptionService:
 
         Mutates the rows in the current session but does NOT commit — the
         caller owns the transaction so it can roll back on partial
-        failure if it chooses to. The fingerprint row is also updated to
-        the new key's fingerprint on the same flush.
+        failure if it chooses to. The fingerprint row is updated to the
+        new key's fingerprint inline so the active fingerprint moves
+        atomically with the row mutations on the caller's commit.
 
         Returns {"success": N, "failed": N, "errors": [Setting.key, ...]}.
         Rows that fail to decrypt under old_key are skipped (their value
         is left as-is); the caller decides whether to abort or proceed
         based on the report.
+
+        Transaction contract — DO NOT MIX with _upsert_setting in the
+        same transaction. This method handles the fingerprint row with a
+        direct ORM mutation / session.add() so it aligns with the row
+        mutation pattern above. Calling _upsert_setting in the same
+        transaction would issue a second concurrent UPSERT for the same
+        key and confuse SQLAlchemy's identity map. Endpoints that wrap
+        reencrypt_all should commit on the same session immediately and
+        not stack other Setting writes before that commit.
         """
         from src.models import Setting
 
         old_fernet = Fernet(old_key.encode())
         new_fernet = Fernet(new_key.encode())
 
-        result = await self.session.execute(
-            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
-        )
         success = 0
         failed = 0
         errors: list[str] = []
-        for row in result.scalars():
+        async for row in self._iter_encrypted_api_key_rows():
             try:
                 plaintext = old_fernet.decrypt(row.value.encode())
             except InvalidToken:

--- a/src/services/crypto.py
+++ b/src/services/crypto.py
@@ -30,9 +30,10 @@ class EncryptionService:
     Stateless cryptographic primitives are exposed as @staticmethod so
     callers that do not need a DB session can use them directly. The
     DB-aware helpers (`get_stored_fingerprint`, `all_api_keys_decrypt`,
-    `validate_stored_keys`, `reencrypt_all`) are instance methods bound
-    to the AsyncSession passed at construction — that keeps the call
-    sites lock-step with FastAPI's request-scoped session lifecycle.
+    `api_key_status`, `validate_stored_keys`, `reencrypt_all`) are
+    instance methods bound to the AsyncSession passed at construction —
+    that keeps the call sites lock-step with FastAPI's request-scoped
+    session lifecycle.
 
     Module-level shims (`encrypt`, `decrypt`, `decrypt_credential`,
     `get_fingerprint`) below preserve the pre-refactor import surface so
@@ -198,6 +199,16 @@ class EncryptionService:
         is left as-is); the caller decides whether to abort or proceed
         based on the report.
 
+        Fingerprint stamping is gated on `failed == 0` for the same
+        reason save_key gates on `all_api_keys_decrypt`: if we advanced
+        the fingerprint while undecryptable rows remained, list_keys
+        would stop emitting `key_mismatch` against them — the rotation
+        banner would disappear from the Settings page even though the
+        rotation is genuinely incomplete. Leaving the fingerprint stale
+        keeps the rotation signal visible for the residual rows until
+        the operator clears them manually (or supplies a key under which
+        they decrypt).
+
         Transaction contract — DO NOT MIX with _upsert_setting in the
         same transaction. This method handles the fingerprint row with a
         direct ORM mutation / session.add() so it aligns with the row
@@ -226,17 +237,21 @@ class EncryptionService:
             row.updated_at = datetime.now(UTC)
             success += 1
 
-        # Refresh the fingerprint so list_keys stops reporting key_mismatch
-        # against the rows that were just re-encrypted. The caller's commit
-        # carries this change atomically with the row updates.
-        new_fingerprint = hashlib.sha256(new_key.encode()).hexdigest()
-        fp_result = await self.session.execute(select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
-        fp_row = fp_result.scalar_one_or_none()
-        if fp_row is not None:
-            fp_row.value = new_fingerprint
-            fp_row.updated_at = datetime.now(UTC)
-        else:
-            self.session.add(Setting(key=ENCRYPTION_KEY_FINGERPRINT_SETTING, value=new_fingerprint, encrypted=False))
+        # Only stamp the new fingerprint when the rotation is fully complete.
+        # See docstring for why partial-success cases must leave it stale.
+        if failed == 0:
+            new_fingerprint = hashlib.sha256(new_key.encode()).hexdigest()
+            fp_result = await self.session.execute(
+                select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING)
+            )
+            fp_row = fp_result.scalar_one_or_none()
+            if fp_row is not None:
+                fp_row.value = new_fingerprint
+                fp_row.updated_at = datetime.now(UTC)
+            else:
+                self.session.add(
+                    Setting(key=ENCRYPTION_KEY_FINGERPRINT_SETTING, value=new_fingerprint, encrypted=False)
+                )
 
         return {"success": success, "failed": failed, "errors": errors}
 

--- a/src/services/crypto.py
+++ b/src/services/crypto.py
@@ -124,6 +124,43 @@ class EncryptionService:
                 return False
         return True
 
+    async def api_key_status(self) -> tuple[bool, bool]:
+        """Return (has_decryptable, has_undecryptable) for stored api_key.% rows.
+
+        A row is "undecryptable" when DecryptionError is raised — typically
+        because ENCRYPTION_KEY was changed after the row was written. Both
+        flags surface so callers can distinguish "no keys at all" from
+        "keys exist but the active ENCRYPTION_KEY can't decrypt them" — the
+        latter needs a user-visible warning, not a silent /setup redirect
+        followed by a later crash in transcribe._get_credential().
+
+        Deliberately does not catch RuntimeError. _get_fernet() raises
+        RuntimeError when ENCRYPTION_KEY is unset, which is a server
+        misconfiguration — not a data-state recovery scenario. Letting it
+        propagate fails fast and signals "fix the env var" rather than
+        misdirecting the user to a recovery banner they cannot act on.
+        """
+        from src.models import Setting
+
+        result = await self.session.execute(
+            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
+        )
+        has_decryptable = False
+        has_undecryptable = False
+        for row in result.scalars():
+            # Fernet decrypt does signature verification — stop as soon as
+            # both flags are set so request-path callers (landing, upload)
+            # don't burn cycles on every additional row when the answer is
+            # already decided.
+            if has_decryptable and has_undecryptable:
+                break
+            try:
+                EncryptionService.decrypt_credential(row.value)
+                has_decryptable = True
+            except DecryptionError:
+                has_undecryptable = True
+        return has_decryptable, has_undecryptable
+
     async def validate_stored_keys(self) -> dict[str, bool]:
         """Per-row decrypt status for every encrypted api_key.% row.
 

--- a/src/services/crypto.py
+++ b/src/services/crypto.py
@@ -1,8 +1,18 @@
 import hashlib
+from datetime import UTC, datetime
 
 from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import settings
+
+# Setting.key prefixes whose rows must be stored encrypted.
+# _upsert_setting derives the `encrypted` flag from this set when the
+# caller does not pass one explicitly — see src/api/settings.py.
+# Adding a new prefix here is the only step needed to make a new
+# Setting namespace encrypted-by-default.
+ENCRYPTED_KEY_PREFIXES: frozenset[str] = frozenset({"api_key."})
 
 # Setting.key used as the storage slot for the active ENCRYPTION_KEY fingerprint.
 # Stored at save time and compared on read to detect rotation without trying
@@ -14,53 +24,195 @@ class DecryptionError(RuntimeError):
     """Stored value cannot be decrypted — encryption key was rotated or replaced."""
 
 
-def _get_fernet() -> Fernet:
-    if not settings.encryption_key:
-        raise RuntimeError(
-            "ENCRYPTION_KEY is not set. Generate one with: "
-            'python -c "from cryptography.fernet import Fernet; '
-            'print(Fernet.generate_key().decode())"'
+class EncryptionService:
+    """ENCRYPTION_KEY-bound operations consolidated into one place.
+
+    Stateless cryptographic primitives are exposed as @staticmethod so
+    callers that do not need a DB session can use them directly. The
+    DB-aware helpers (`get_stored_fingerprint`, `all_api_keys_decrypt`,
+    `validate_stored_keys`, `reencrypt_all`) are instance methods bound
+    to the AsyncSession passed at construction — that keeps the call
+    sites lock-step with FastAPI's request-scoped session lifecycle.
+
+    Module-level shims (`encrypt`, `decrypt`, `decrypt_credential`,
+    `get_fingerprint`) below preserve the pre-refactor import surface so
+    existing callers and tests do not need to migrate in one step.
+    """
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    @staticmethod
+    def _get_fernet() -> Fernet:
+        if not settings.encryption_key:
+            raise RuntimeError(
+                "ENCRYPTION_KEY is not set. Generate one with: "
+                'python -c "from cryptography.fernet import Fernet; '
+                'print(Fernet.generate_key().decode())"'
+            )
+        return Fernet(settings.encryption_key.encode())
+
+    @staticmethod
+    def encrypt(plaintext: str) -> str:
+        return EncryptionService._get_fernet().encrypt(plaintext.encode()).decode()
+
+    @staticmethod
+    def decrypt(ciphertext: str) -> str:
+        return EncryptionService._get_fernet().decrypt(ciphertext.encode()).decode()
+
+    @staticmethod
+    def decrypt_credential(ciphertext: str) -> str:
+        """Decrypt a stored credential.
+
+        Raises DecryptionError if ENCRYPTION_KEY has changed since the
+        value was encrypted, so callers can surface a user-friendly
+        recovery message instead of crashing with a raw InvalidToken.
+        """
+        try:
+            return EncryptionService.decrypt(ciphertext)
+        except InvalidToken:
+            raise DecryptionError(
+                "Encryption key has changed. Please re-enter your API key in Settings → API Keys."
+            ) from None
+
+    @staticmethod
+    def get_fingerprint() -> str:
+        """SHA-256 hex of the ENCRYPTION_KEY string's UTF-8 bytes.
+
+        Fernet keys are base64-encoded text; we hash that text directly
+        rather than base64-decoding it first — the fingerprint is only an
+        identity check, not a cryptographic transform of the underlying
+        key material, so hashing the canonical string form is sufficient
+        and avoids a decode step.
+
+        Raises RuntimeError when ENCRYPTION_KEY is unset so callers do
+        not silently store an empty fingerprint and mask the misconfig.
+        """
+        if not settings.encryption_key:
+            raise RuntimeError("ENCRYPTION_KEY is not set; cannot compute fingerprint.")
+        return hashlib.sha256(settings.encryption_key.encode()).hexdigest()
+
+    async def get_stored_fingerprint(self) -> str | None:
+        """Return the ENCRYPTION_KEY fingerprint persisted at the last save_key call.
+
+        None means "never stamped" (legacy / fresh install) — callers
+        must treat None as 'unknown', NOT as 'mismatch', so existing
+        users without a stamped fingerprint don't see a false rotation
+        warning until they next save a key.
+        """
+        from src.models import Setting
+
+        result = await self.session.execute(select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
+        setting = result.scalar_one_or_none()
+        return setting.value if setting else None
+
+    async def all_api_keys_decrypt(self) -> bool:
+        """True iff every encrypted api_key.% row decrypts under the active key.
+
+        Gates the fingerprint stamp in save_key: stamping unconditionally
+        would silently lose the rotation signal during partial recovery.
+        """
+        from src.models import Setting
+
+        result = await self.session.execute(
+            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
         )
-    return Fernet(settings.encryption_key.encode())
+        for row in result.scalars():
+            try:
+                EncryptionService.decrypt_credential(row.value)
+            except DecryptionError:
+                return False
+        return True
+
+    async def validate_stored_keys(self) -> dict[str, bool]:
+        """Per-row decrypt status for every encrypted api_key.% row.
+
+        Returned mapping is {Setting.key: True if decrypts else False}.
+        Diagnostic helper — endpoints can use it to render granular
+        per-provider status instead of the binary all-or-nothing signal
+        that all_api_keys_decrypt returns.
+        """
+        from src.models import Setting
+
+        result = await self.session.execute(
+            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
+        )
+        status: dict[str, bool] = {}
+        for row in result.scalars():
+            try:
+                EncryptionService.decrypt_credential(row.value)
+                status[row.key] = True
+            except DecryptionError:
+                status[row.key] = False
+        return status
+
+    async def reencrypt_all(self, old_key: str, new_key: str) -> dict:
+        """Re-encrypt every api_key.% row from old_key to new_key.
+
+        Mutates the rows in the current session but does NOT commit — the
+        caller owns the transaction so it can roll back on partial
+        failure if it chooses to. The fingerprint row is also updated to
+        the new key's fingerprint on the same flush.
+
+        Returns {"success": N, "failed": N, "errors": [Setting.key, ...]}.
+        Rows that fail to decrypt under old_key are skipped (their value
+        is left as-is); the caller decides whether to abort or proceed
+        based on the report.
+        """
+        from src.models import Setting
+
+        old_fernet = Fernet(old_key.encode())
+        new_fernet = Fernet(new_key.encode())
+
+        result = await self.session.execute(
+            select(Setting).where(Setting.key.like("api_key.%"), Setting.encrypted.is_(True))
+        )
+        success = 0
+        failed = 0
+        errors: list[str] = []
+        for row in result.scalars():
+            try:
+                plaintext = old_fernet.decrypt(row.value.encode())
+            except InvalidToken:
+                failed += 1
+                errors.append(row.key)
+                continue
+            row.value = new_fernet.encrypt(plaintext).decode()
+            row.updated_at = datetime.now(UTC)
+            success += 1
+
+        # Refresh the fingerprint so list_keys stops reporting key_mismatch
+        # against the rows that were just re-encrypted. The caller's commit
+        # carries this change atomically with the row updates.
+        new_fingerprint = hashlib.sha256(new_key.encode()).hexdigest()
+        fp_result = await self.session.execute(select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
+        fp_row = fp_result.scalar_one_or_none()
+        if fp_row is not None:
+            fp_row.value = new_fingerprint
+            fp_row.updated_at = datetime.now(UTC)
+        else:
+            self.session.add(Setting(key=ENCRYPTION_KEY_FINGERPRINT_SETTING, value=new_fingerprint, encrypted=False))
+
+        return {"success": success, "failed": failed, "errors": errors}
+
+
+# Backward-compatibility shims for the pre-refactor module-level API.
+# New callers should use EncryptionService directly; these wrappers keep
+# the existing `from src.services.crypto import encrypt, decrypt, ...`
+# imports working so the refactor stays scoped to one PR.
 
 
 def encrypt(plaintext: str) -> str:
-    return _get_fernet().encrypt(plaintext.encode()).decode()
+    return EncryptionService.encrypt(plaintext)
 
 
 def decrypt(ciphertext: str) -> str:
-    return _get_fernet().decrypt(ciphertext.encode()).decode()
+    return EncryptionService.decrypt(ciphertext)
 
 
 def decrypt_credential(ciphertext: str) -> str:
-    """Decrypt a stored credential.
-
-    Raises DecryptionError if ENCRYPTION_KEY has changed since the value
-    was encrypted, so callers can surface a user-friendly recovery message
-    instead of crashing with a raw InvalidToken.
-    """
-    try:
-        return decrypt(ciphertext)
-    except InvalidToken:
-        raise DecryptionError(
-            "Encryption key has changed. Please re-enter your API key in Settings → API Keys."
-        ) from None
+    return EncryptionService.decrypt_credential(ciphertext)
 
 
 def get_fingerprint() -> str:
-    """Return a stable, non-reversible fingerprint of the active ENCRYPTION_KEY.
-
-    SHA-256 hex of the ENCRYPTION_KEY string's UTF-8 bytes. Fernet keys are
-    base64-encoded text, and we hash that text directly without
-    base64-decoding it — the fingerprint is only an identity check, not a
-    cryptographic transform of the underlying key material, so hashing the
-    canonical string form is sufficient and avoids dragging in a decode
-    step. The full 64-char digest is returned for exact equality checks;
-    callers that only need a display form should slice locally.
-
-    Raises RuntimeError if ENCRYPTION_KEY is not set — callers should not
-    silently store an empty fingerprint, that would mask the misconfiguration.
-    """
-    if not settings.encryption_key:
-        raise RuntimeError("ENCRYPTION_KEY is not set; cannot compute fingerprint.")
-    return hashlib.sha256(settings.encryption_key.encode()).hexdigest()
+    return EncryptionService.get_fingerprint()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -31,12 +31,17 @@ async def isolated_api_keys():
 
     from src.database import async_session
     from src.models import Setting
-    from src.services.crypto import ENCRYPTION_KEY_FINGERPRINT_SETTING, encrypt
+    from src.services.crypto import encrypt
 
     async def _wipe():
+        # Wipe the api_key namespace (sensitive credentials) and the _meta
+        # namespace (internal metadata + test markers). Broad _meta.% coverage
+        # is intentional so tests can write their own _meta.* probes and rely
+        # on the helper to clean up — without it, a test-specific marker row
+        # would leak into subsequent tests' DB state.
         async with async_session() as s:
             await s.execute(delete(Setting).where(Setting.key.like("api_key.%")))
-            await s.execute(delete(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
+            await s.execute(delete(Setting).where(Setting.key.like("_meta.%")))
             await s.commit()
 
     await _wipe()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -116,3 +116,147 @@ def test_encrypted_key_prefixes_excludes_meta_namespace():
     assert not any(p.startswith("_meta.") for p in ENCRYPTED_KEY_PREFIXES)
     # The active fingerprint key explicitly does not match any prefix.
     assert not any(ENCRYPTION_KEY_FINGERPRINT_SETTING.startswith(p) for p in ENCRYPTED_KEY_PREFIXES)
+
+
+# ─── DB-aware methods (validate_stored_keys, api_key_status, reencrypt_all) ──
+
+
+@pytest.mark.asyncio
+async def test_validate_stored_keys_reports_per_row_status():
+    """validate_stored_keys returns a {Setting.key: bool} map so an endpoint
+    can render granular per-row recovery state, not just the binary
+    all-decrypt signal that all_api_keys_decrypt provides.
+    """
+    from src.database import async_session
+    from src.models import Setting
+    from tests.helpers import isolated_api_keys
+
+    async with isolated_api_keys() as session_factory:
+        async with session_factory() as s:
+            s.add(Setting(key="api_key.openai", value=encrypt("sk-real"), encrypted=True))
+            s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
+            await s.commit()
+
+        async with async_session() as s:
+            status = await EncryptionService(s).validate_stored_keys()
+        assert status == {"api_key.openai": True, "api_key.google": False}
+
+
+@pytest.mark.asyncio
+async def test_api_key_status_short_circuits_when_both_flags_set():
+    """api_key_status pairs the two flags so callers can route on either
+    signal. The implementation should stop iterating once both flags are
+    set — verified indirectly by mixing a decryptable and an undecryptable
+    row and asserting both flags are True.
+    """
+    from src.database import async_session
+    from src.models import Setting
+    from tests.helpers import isolated_api_keys
+
+    async with isolated_api_keys() as session_factory:
+        async with session_factory() as s:
+            s.add(Setting(key="api_key.openai", value=encrypt("sk-real"), encrypted=True))
+            s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
+            await s.commit()
+
+        async with async_session() as s:
+            has_decryptable, has_undecryptable = await EncryptionService(s).api_key_status()
+        assert has_decryptable is True
+        assert has_undecryptable is True
+
+
+@pytest.mark.asyncio
+async def test_reencrypt_all_rewrites_rows_and_updates_fingerprint():
+    """Happy-path rotation: every encrypted row is re-encrypted from old_key
+    to new_key, the active fingerprint is set to new_key's, and the report
+    reflects success=N / failed=0.
+    """
+    import hashlib
+
+    from sqlalchemy import select
+
+    from src.database import async_session
+    from src.models import Setting
+    from tests.helpers import isolated_api_keys
+
+    old_key = Fernet.generate_key().decode()
+    new_key = Fernet.generate_key().decode()
+
+    async with isolated_api_keys() as session_factory:
+        async with session_factory() as s:
+            # Two rows encrypted under the OLD key — what a real pre-rotation
+            # DB looks like.
+            old_fernet = Fernet(old_key.encode())
+            s.add(
+                Setting(
+                    key="api_key.openai",
+                    value=old_fernet.encrypt(b"sk-openai").decode(),
+                    encrypted=True,
+                )
+            )
+            s.add(
+                Setting(
+                    key="api_key.google",
+                    value=old_fernet.encrypt(b"sk-google").decode(),
+                    encrypted=True,
+                )
+            )
+            await s.commit()
+
+        async with async_session() as s:
+            report = await EncryptionService(s).reencrypt_all(old_key, new_key)
+            await s.commit()
+        assert report == {"success": 2, "failed": 0, "errors": []}
+
+        # Verify rows are now decryptable under new_key.
+        new_fernet = Fernet(new_key.encode())
+        async with async_session() as s:
+            result = await s.execute(select(Setting).where(Setting.key.like("api_key.%")))
+            for row in result.scalars():
+                # If the value was correctly re-encrypted, new_fernet.decrypt
+                # succeeds and returns the original plaintext.
+                assert new_fernet.decrypt(row.value.encode()) in (b"sk-openai", b"sk-google")
+
+            # Fingerprint row points to the NEW key — list_keys downstream will
+            # match against the active fingerprint and stop flagging mismatch.
+            fp_result = await s.execute(select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
+            fp_row = fp_result.scalar_one_or_none()
+        expected_new_fp = hashlib.sha256(new_key.encode()).hexdigest()
+        assert fp_row is not None
+        assert fp_row.value == expected_new_fp
+
+
+@pytest.mark.asyncio
+async def test_reencrypt_all_reports_failures_without_aborting():
+    """If a row fails to decrypt under old_key (e.g. it was already encrypted
+    under a third unknown key), reencrypt_all records it in `errors` and
+    proceeds with the rest. The caller — not the service — decides whether
+    a partial result is acceptable.
+    """
+    from src.database import async_session
+    from src.models import Setting
+    from tests.helpers import foreign_fernet_token, isolated_api_keys
+
+    old_key = Fernet.generate_key().decode()
+    new_key = Fernet.generate_key().decode()
+    old_fernet = Fernet(old_key.encode())
+
+    async with isolated_api_keys() as session_factory:
+        async with session_factory() as s:
+            s.add(
+                Setting(
+                    key="api_key.openai",
+                    value=old_fernet.encrypt(b"sk-recoverable").decode(),
+                    encrypted=True,
+                )
+            )
+            # Row encrypted under a THIRD key — neither old_key nor new_key.
+            s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
+            await s.commit()
+
+        async with async_session() as s:
+            report = await EncryptionService(s).reencrypt_all(old_key, new_key)
+            await s.commit()
+    assert report["success"] == 1
+    assert report["failed"] == 1
+    assert report["errors"] == ["api_key.google"]

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -220,10 +220,17 @@ async def test_reencrypt_all_reports_failures_without_aborting():
     under a third unknown key), reencrypt_all records it in `errors` and
     proceeds with the rest. The caller — not the service — decides whether
     a partial result is acceptable.
+
+    Additional invariant: when failed > 0 the stored fingerprint MUST stay
+    stale. Advancing it would silently clear the rotation banner from the
+    Settings page while undecryptable rows remain — exactly the same class
+    of partial-recovery hole that #67 + save_key already guard against.
     """
     old_key = Fernet.generate_key().decode()
     new_key = Fernet.generate_key().decode()
     old_fernet = Fernet(old_key.encode())
+    # Pre-stamp a known fingerprint we can compare against post-call.
+    stale_fp = "deadbeef" * 8
 
     async with isolated_api_keys() as session_factory:
         async with session_factory() as s:
@@ -236,11 +243,21 @@ async def test_reencrypt_all_reports_failures_without_aborting():
             )
             # Row encrypted under a THIRD key — neither old_key nor new_key.
             s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
+            s.add(Setting(key=ENCRYPTION_KEY_FINGERPRINT_SETTING, value=stale_fp, encrypted=False))
             await s.commit()
 
         async with session_factory() as s:
             report = await EncryptionService(s).reencrypt_all(old_key, new_key)
             await s.commit()
-    assert report["success"] == 1
-    assert report["failed"] == 1
-    assert report["errors"] == ["api_key.google"]
+        assert report["success"] == 1
+        assert report["failed"] == 1
+        assert report["errors"] == ["api_key.google"]
+
+        # The fingerprint must NOT have advanced to new_key's hash, because
+        # one row still cannot be decrypted under new_key. Leaving it stale
+        # keeps list_keys' rotation banner alive for the residual row.
+        async with session_factory() as s:
+            fp_row = (
+                await s.execute(select(Setting).where(Setting.key == ENCRYPTION_KEY_FINGERPRINT_SETTING))
+            ).scalar_one()
+        assert fp_row.value == stale_fp, "partial-failure rotation must not stamp a fresh fingerprint"

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -5,7 +5,10 @@ from cryptography.fernet import Fernet
 
 from src.config import settings as app_settings
 from src.services.crypto import (
+    ENCRYPTED_KEY_PREFIXES,
+    ENCRYPTION_KEY_FINGERPRINT_SETTING,
     DecryptionError,
+    EncryptionService,
     decrypt,
     decrypt_credential,
     encrypt,
@@ -71,3 +74,45 @@ def test_get_fingerprint_raises_when_key_unset(monkeypatch):
     monkeypatch.setattr(app_settings, "encryption_key", "")
     with pytest.raises(RuntimeError):
         get_fingerprint()
+
+
+# ─── EncryptionService class — same contracts via the class API ────────────
+
+
+def test_encryption_service_static_methods_match_module_wrappers():
+    """The class-level API and the module-level shims must return identical
+    results — the shims are intentionally thin and must not diverge.
+    """
+    token = EncryptionService.encrypt("sk-class-vs-module")
+    assert EncryptionService.decrypt(token) == "sk-class-vs-module"
+    assert EncryptionService.decrypt(token) == decrypt(token)
+    assert EncryptionService.get_fingerprint() == get_fingerprint()
+
+
+def test_encryption_service_decrypt_credential_raises_decryption_error():
+    """The class method honors the same DecryptionError contract as the shim,
+    so callers can migrate from `decrypt_credential(...)` to
+    `EncryptionService.decrypt_credential(...)` without changing their
+    `except` clause.
+    """
+    with pytest.raises(DecryptionError):
+        EncryptionService.decrypt_credential(foreign_fernet_token())
+
+
+def test_encrypted_key_prefixes_contains_api_key():
+    """The api_key.<provider> namespace is the canonical encrypted slot.
+    Removing it from this set would silently downgrade live API keys to
+    plaintext on the next save — pin the membership.
+    """
+    assert "api_key." in ENCRYPTED_KEY_PREFIXES
+
+
+def test_encrypted_key_prefixes_excludes_meta_namespace():
+    """The _meta.* namespace must NOT be in the encrypted-by-default set —
+    fingerprint rows and similar metadata are intentionally plaintext.
+    A regression here would write hashes to the DB encrypted under a
+    rotating key, defeating their purpose as rotation detectors.
+    """
+    assert not any(p.startswith("_meta.") for p in ENCRYPTED_KEY_PREFIXES)
+    # The active fingerprint key explicitly does not match any prefix.
+    assert not any(ENCRYPTION_KEY_FINGERPRINT_SETTING.startswith(p) for p in ENCRYPTED_KEY_PREFIXES)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,9 +1,13 @@
 """Tests for src.services.crypto."""
 
+import hashlib
+
 import pytest
 from cryptography.fernet import Fernet
+from sqlalchemy import select
 
 from src.config import settings as app_settings
+from src.models import Setting
 from src.services.crypto import (
     ENCRYPTED_KEY_PREFIXES,
     ENCRYPTION_KEY_FINGERPRINT_SETTING,
@@ -14,7 +18,7 @@ from src.services.crypto import (
     encrypt,
     get_fingerprint,
 )
-from tests.helpers import foreign_fernet_token
+from tests.helpers import foreign_fernet_token, isolated_api_keys
 
 
 def test_encrypt_decrypt_roundtrip():
@@ -127,17 +131,13 @@ async def test_validate_stored_keys_reports_per_row_status():
     can render granular per-row recovery state, not just the binary
     all-decrypt signal that all_api_keys_decrypt provides.
     """
-    from src.database import async_session
-    from src.models import Setting
-    from tests.helpers import isolated_api_keys
-
     async with isolated_api_keys() as session_factory:
         async with session_factory() as s:
             s.add(Setting(key="api_key.openai", value=encrypt("sk-real"), encrypted=True))
             s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
             await s.commit()
 
-        async with async_session() as s:
+        async with session_factory() as s:
             status = await EncryptionService(s).validate_stored_keys()
         assert status == {"api_key.openai": True, "api_key.google": False}
 
@@ -149,17 +149,13 @@ async def test_api_key_status_short_circuits_when_both_flags_set():
     set — verified indirectly by mixing a decryptable and an undecryptable
     row and asserting both flags are True.
     """
-    from src.database import async_session
-    from src.models import Setting
-    from tests.helpers import isolated_api_keys
-
     async with isolated_api_keys() as session_factory:
         async with session_factory() as s:
             s.add(Setting(key="api_key.openai", value=encrypt("sk-real"), encrypted=True))
             s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
             await s.commit()
 
-        async with async_session() as s:
+        async with session_factory() as s:
             has_decryptable, has_undecryptable = await EncryptionService(s).api_key_status()
         assert has_decryptable is True
         assert has_undecryptable is True
@@ -171,14 +167,6 @@ async def test_reencrypt_all_rewrites_rows_and_updates_fingerprint():
     to new_key, the active fingerprint is set to new_key's, and the report
     reflects success=N / failed=0.
     """
-    import hashlib
-
-    from sqlalchemy import select
-
-    from src.database import async_session
-    from src.models import Setting
-    from tests.helpers import isolated_api_keys
-
     old_key = Fernet.generate_key().decode()
     new_key = Fernet.generate_key().decode()
 
@@ -203,14 +191,14 @@ async def test_reencrypt_all_rewrites_rows_and_updates_fingerprint():
             )
             await s.commit()
 
-        async with async_session() as s:
+        async with session_factory() as s:
             report = await EncryptionService(s).reencrypt_all(old_key, new_key)
             await s.commit()
         assert report == {"success": 2, "failed": 0, "errors": []}
 
         # Verify rows are now decryptable under new_key.
         new_fernet = Fernet(new_key.encode())
-        async with async_session() as s:
+        async with session_factory() as s:
             result = await s.execute(select(Setting).where(Setting.key.like("api_key.%")))
             for row in result.scalars():
                 # If the value was correctly re-encrypted, new_fernet.decrypt
@@ -233,10 +221,6 @@ async def test_reencrypt_all_reports_failures_without_aborting():
     proceeds with the rest. The caller — not the service — decides whether
     a partial result is acceptable.
     """
-    from src.database import async_session
-    from src.models import Setting
-    from tests.helpers import foreign_fernet_token, isolated_api_keys
-
     old_key = Fernet.generate_key().decode()
     new_key = Fernet.generate_key().decode()
     old_fernet = Fernet(old_key.encode())
@@ -254,7 +238,7 @@ async def test_reencrypt_all_reports_failures_without_aborting():
             s.add(Setting(key="api_key.google", value=foreign_fernet_token(), encrypted=True))
             await s.commit()
 
-        async with async_session() as s:
+        async with session_factory() as s:
             report = await EncryptionService(s).reencrypt_all(old_key, new_key)
             await s.commit()
     assert report["success"] == 1

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -365,26 +365,20 @@ async def test_upsert_setting_defaults_plain_for_non_prefixed_keys():
     regression here would write the SHA-256 hash through Fernet and break
     the rotation detector.
     """
-    from sqlalchemy import delete, select
+    from sqlalchemy import select
 
     from src.api.settings import _upsert_setting
-    from src.database import async_session
 
     test_key = "_meta.test_upsert_classification_marker"
-    async with async_session() as s:
-        await s.execute(delete(Setting).where(Setting.key == test_key))
-        await _upsert_setting(s, test_key, "plaintext-marker")
-        await s.commit()
+    async with isolated_api_keys() as session_factory:
+        async with session_factory() as s:
+            await _upsert_setting(s, test_key, "plaintext-marker")
+            await s.commit()
 
-    try:
-        async with async_session() as s:
+        async with session_factory() as s:
             row = (await s.execute(select(Setting).where(Setting.key == test_key))).scalar_one()
         assert row.encrypted is False
         assert row.value == "plaintext-marker"
-    finally:
-        async with async_session() as s:
-            await s.execute(delete(Setting).where(Setting.key == test_key))
-            await s.commit()
 
 
 @pytest.mark.asyncio

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -344,27 +344,18 @@ async def test_upsert_setting_auto_encrypts_api_key_namespace():
     forgetting to pass encrypted=True would previously have written
     plaintext credentials to the DB.
     """
-    from sqlalchemy import delete, select
+    from sqlalchemy import select
 
     from src.api.settings import _upsert_setting
-    from src.database import async_session
 
-    async with async_session() as s:
-        await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
-        await _upsert_setting(s, "api_key.openai", "stub-ciphertext")
-        await s.commit()
+    async with isolated_api_keys() as session_factory:
+        async with session_factory() as s:
+            await _upsert_setting(s, "api_key.openai", "stub-ciphertext")
+            await s.commit()
 
-    try:
-        async with async_session() as s:
+        async with session_factory() as s:
             row = (await s.execute(select(Setting).where(Setting.key == "api_key.openai"))).scalar_one()
         assert row.encrypted is True
-    finally:
-        from src.services.crypto import encrypt
-
-        async with async_session() as s:
-            await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
-            s.add(Setting(key="api_key.openai", value=encrypt("sk-test"), encrypted=True))
-            await s.commit()
 
 
 @pytest.mark.asyncio

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -332,3 +332,83 @@ async def test_list_keys_omits_key_mismatch_when_no_stamped_fingerprint(make_cli
         assert google_entry is not None
         assert google_entry.get("decryption_error") is True
         assert "key_mismatch" not in google_entry
+
+
+# ─── _upsert_setting auto-detect contract (#71) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_setting_auto_encrypts_api_key_namespace():
+    """api_key.<provider> keys must be persisted with encrypted=True when the
+    caller omits the explicit flag. This is the safety net that #71 adds —
+    forgetting to pass encrypted=True would previously have written
+    plaintext credentials to the DB.
+    """
+    from sqlalchemy import delete, select
+
+    from src.api.settings import _upsert_setting
+    from src.database import async_session
+
+    async with async_session() as s:
+        await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
+        await _upsert_setting(s, "api_key.openai", "stub-ciphertext")
+        await s.commit()
+
+    try:
+        async with async_session() as s:
+            row = (await s.execute(select(Setting).where(Setting.key == "api_key.openai"))).scalar_one()
+        assert row.encrypted is True
+    finally:
+        from src.services.crypto import encrypt
+
+        async with async_session() as s:
+            await s.execute(delete(Setting).where(Setting.key == "api_key.openai"))
+            s.add(Setting(key="api_key.openai", value=encrypt("sk-test"), encrypted=True))
+            await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_upsert_setting_defaults_plain_for_non_prefixed_keys():
+    """Keys outside ENCRYPTED_KEY_PREFIXES default to encrypted=False — the
+    _meta.encryption_key_fingerprint row is the canonical example. A
+    regression here would write the SHA-256 hash through Fernet and break
+    the rotation detector.
+    """
+    from sqlalchemy import delete, select
+
+    from src.api.settings import _upsert_setting
+    from src.database import async_session
+
+    test_key = "_meta.test_upsert_classification_marker"
+    async with async_session() as s:
+        await s.execute(delete(Setting).where(Setting.key == test_key))
+        await _upsert_setting(s, test_key, "plaintext-marker")
+        await s.commit()
+
+    try:
+        async with async_session() as s:
+            row = (await s.execute(select(Setting).where(Setting.key == test_key))).scalar_one()
+        assert row.encrypted is False
+        assert row.value == "plaintext-marker"
+    finally:
+        async with async_session() as s:
+            await s.execute(delete(Setting).where(Setting.key == test_key))
+            await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_upsert_setting_rejects_plaintext_for_encrypted_prefix():
+    """`encrypted=False` for a key in ENCRYPTED_KEY_PREFIXES is a contract
+    violation — the prefix declaration is exactly what the safety net
+    relies on. The function must raise instead of silently writing
+    plaintext credentials.
+    """
+    from src.api.settings import _upsert_setting
+    from src.database import async_session
+
+    async with async_session() as s:
+        with pytest.raises(ValueError, match="ENCRYPTED_KEY_PREFIXES"):
+            await _upsert_setting(s, "api_key.openai", "would-be-plaintext", encrypted=False)
+        # Roll back so the bad write does not persist even though we raised
+        # before the commit.
+        await s.rollback()


### PR DESCRIPTION
Closes #70
Closes #71

## Summary

- Introduce `EncryptionService` class in `src/services/crypto.py` consolidating every ENCRYPTION_KEY-bound operation. Stateless primitives stay `@staticmethod`; DB-aware helpers (`get_stored_fingerprint`, `all_api_keys_decrypt`, `validate_stored_keys`, `api_key_status`, `reencrypt_all`) are instance methods bound to `AsyncSession`. (#70)
- Add `ENCRYPTED_KEY_PREFIXES = frozenset({"api_key."})` as the canonical declaration of sensitive namespaces. `_upsert_setting(encrypted=None)` auto-detects the flag from the key prefix and rejects `encrypted=False` for prefix-matched keys with `ValueError` — fail-fast against accidental plaintext credential storage. (#71)
- Migrate `pages.py:_has_api_keys`/`setup_page` and `settings.py:list_keys`/`save_key` to `EncryptionService(session)`. The legacy `_get_stored_fingerprint`, `_all_api_keys_decrypt`, `_api_key_status` helpers are fully removed from settings.py/pages.py.
- `reencrypt_all(old_key, new_key)` is implemented now (PR-C #68 endpoint will be the sole caller). Decrypts every `api_key.%` row under `old_key`, re-encrypts under `new_key`, and refreshes the `_meta.encryption_key_fingerprint` row inline. Caller owns the transaction.

## Implementation notes

- **Backward compatibility**: module-level shims for `encrypt`/`decrypt`/`decrypt_credential`/`get_fingerprint` are kept as thin wrappers calling the class — preserves `from src.services.crypto import encrypt` imports throughout `transcribe.py` and the test suite. Caller migration is deliberately incremental.
- **Scanner DRY**: introduced `_iter_encrypted_api_key_rows` async generator as the single source of truth for the `Setting.key.like("api_key.%") + encrypted.is_(True)` predicate. The four scanner methods (`all_api_keys_decrypt`, `api_key_status`, `validate_stored_keys`, `reencrypt_all`) all delegate to it — changing the predicate once propagates correctly.
- **`reencrypt_all` transaction contract**: the docstring explicitly forbids mixing with `_upsert_setting` in the same transaction. The fingerprint row is mutated inline via direct ORM access so the identity map stays coherent. PR-C #68's endpoint must commit immediately after the call returns.
- **`_upsert_setting` invariant**: passing `encrypted=False` for a key matching `ENCRYPTED_KEY_PREFIXES` is now a `ValueError`. There are zero real callers doing this today, but the contract pins the safety net for future code.
- **Eye-fresh cleanup**: `test_crypto.py` imports consolidated to module-level, all DB-aware test blocks use `isolated_api_keys() as session_factory` + `session_factory()` consistently (no leftover direct `async_session()` opens).
- **No schema migrations**. The fingerprint row uses the existing `Setting` table — `_meta.*` namespace convention (introduced in PR-A) carries forward.
- **Docs**: `.claude/rules/encrypted-settings.md` updated with the namespace table (`api_key.*` / `_meta.*` / everything-else), the `_upsert_setting` contract, and the "extend `ENCRYPTED_KEY_PREFIXES` to add a new namespace, do not per-callsite override" rule.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens, batch coherence + PR-A integration review)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/70-batch-70-71.gate1.md
- ~/.claude/cache/gh-issue-driven/70-batch-70-71.gate2.md

🤖 Generated via /gh-issue-driven:ship
