### PR TITLE
fix(api): align SRT editor audio with subtitle timeline (#73)

### DIFF
--- a/alembic/versions/d4f8a2b6c1e9_add_audio_path_to_jobs.py
+++ b/alembic/versions/d4f8a2b6c1e9_add_audio_path_to_jobs.py
@@ -1,0 +1,27 @@
+"""add audio_path to jobs
+
+Revision ID: d4f8a2b6c1e9
+Revises: 7a2b5d55730d
+Create Date: 2026-05-16 04:50:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4f8a2b6c1e9"
+down_revision: Union[str, None] = "7a2b5d55730d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("audio_path", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "audio_path")

--- a/src/api/jobs.py
+++ b/src/api/jobs.py
@@ -407,33 +407,77 @@ async def download_vtt(
     )
 
 
+_MEDIA_TYPES = {
+    ".mp4": "video/mp4",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".m4a": "audio/mp4",
+    ".ogg": "audio/ogg",
+    ".flac": "audio/flac",
+    ".webm": "audio/webm",
+    ".mov": "video/quicktime",
+    ".avi": "video/x-msvideo",
+    ".mkv": "video/x-matroska",
+}
+
+
+def _find_upload_path(job_id: str) -> Path | None:
+    """Return the original uploaded file for this job, or None if missing.
+
+    Callers can treat a non-None result as existing on disk; ``Path.glob``
+    only yields entries that exist at iteration time, so no extra stat is
+    needed here.
+    """
+    for f in settings.uploads_dir.glob(f"{job_id}.*"):
+        return f
+    return None
+
+
+def _resolve_playback_path(job: Job) -> Path | None:
+    """Pick the file the editor should play to keep timestamps aligned.
+
+    Prefer the persisted extracted audio (``job.audio_path``) because the
+    transcription timeline is anchored to it. Fall back to the original
+    upload for legacy jobs that predate the column or had their extracted
+    audio removed.
+
+    Returns a Path that is guaranteed to exist, or None if neither source
+    is available.
+    """
+    if job.audio_path:
+        p = Path(job.audio_path)
+        if p.exists():
+            return p
+    return _find_upload_path(job.id)
+
+
 @router.get("/{job_id}/media")
 async def get_media(job_id: str, session: AsyncSession = Depends(get_session)):
-    """Serve the original uploaded media file for audio playback."""
+    """Serve the original uploaded media file (download / future video preview)."""
     job = await _get_job_or_404(session, job_id)
 
-    # Find uploaded file
-    media_path = None
-    for f in settings.uploads_dir.glob(f"{job.id}.*"):
-        media_path = f
-        break
-    if not media_path or not media_path.exists():
+    media_path = _find_upload_path(job.id)
+    if media_path is None:
         raise media_not_found()
 
-    ext = media_path.suffix.lower()
-    media_types = {
-        ".mp4": "video/mp4",
-        ".mp3": "audio/mpeg",
-        ".wav": "audio/wav",
-        ".m4a": "audio/mp4",
-        ".ogg": "audio/ogg",
-        ".flac": "audio/flac",
-        ".webm": "audio/webm",
-        ".mov": "video/quicktime",
-        ".avi": "video/x-msvideo",
-        ".mkv": "video/x-matroska",
-    }
-    return FileResponse(media_path, media_type=media_types.get(ext, "application/octet-stream"))
+    return FileResponse(media_path, media_type=_MEDIA_TYPES.get(media_path.suffix.lower(), "application/octet-stream"))
+
+
+@router.get("/{job_id}/audio")
+async def get_audio(job_id: str, session: AsyncSession = Depends(get_session)):
+    """Serve the audio whose timeline matches the SRT segments.
+
+    Prefers the extracted audio recorded in ``job.audio_path`` so the editor's
+    `<audio>` playhead stays aligned with subtitle timestamps. Falls back to
+    the original upload for legacy jobs.
+    """
+    job = await _get_job_or_404(session, job_id)
+
+    audio_path = _resolve_playback_path(job)
+    if audio_path is None:
+        raise media_not_found()
+
+    return FileResponse(audio_path, media_type=_MEDIA_TYPES.get(audio_path.suffix.lower(), "application/octet-stream"))
 
 
 @router.get("/{job_id}/peaks")
@@ -443,15 +487,14 @@ async def get_peaks(job_id: str, session: AsyncSession = Depends(get_session)):
 
     job = await _get_job_or_404(session, job_id)
 
-    media_path = None
-    for f in settings.uploads_dir.glob(f"{job.id}.*"):
-        media_path = f
-        break
-    if not media_path or not media_path.exists():
+    # Generate peaks from the same source the editor plays back so the
+    # waveform timeline matches the SRT segments byte-for-byte.
+    source_path = _resolve_playback_path(job)
+    if source_path is None:
         raise media_not_found()
 
     try:
-        return await get_or_generate_peaks(job.id, media_path, settings.peaks_dir)
+        return await get_or_generate_peaks(job.id, source_path, settings.peaks_dir)
     except Exception as e:
         logger.warning("Peak generation failed for job %s: %s", job.id, e)
         raise AppError(500, "PEAKS_FAILED", "Could not generate waveform peaks") from e
@@ -881,13 +924,17 @@ async def delete_job(job_id: str, session: AsyncSession = Depends(get_session)):
     await session.delete(job)
     await session.commit()
 
-    # Clean up files (best effort)
-    for path_str in [job.srt_path]:
+    # Clean up files (best effort). Persisted paths first — the SRT and the
+    # extracted audio both live at locations recorded on the row, so we delete
+    # them explicitly in case they ever move outside the default data dirs.
+    for path_str in [job.srt_path, job.audio_path]:
         if path_str:
             Path(path_str).unlink(missing_ok=True)
 
-    # Clean up upload and audio files (any extension)
-    for d in [settings.uploads_dir, settings.audio_dir]:
+    # Sweep the default data dirs as a backstop for chunks, peaks files, and
+    # any leftover artifacts whose paths aren't recorded on the row. Including
+    # peaks_dir here is what prevents data/peaks/{job_id}.json from leaking.
+    for d in [settings.uploads_dir, settings.audio_dir, settings.peaks_dir]:
         for f in d.glob(f"{job.id}.*"):
             f.unlink(missing_ok=True)
 

--- a/src/api/jobs.py
+++ b/src/api/jobs.py
@@ -931,12 +931,19 @@ async def delete_job(job_id: str, session: AsyncSession = Depends(get_session)):
         if path_str:
             Path(path_str).unlink(missing_ok=True)
 
-    # Sweep the default data dirs as a backstop for chunks, peaks files, and
-    # any leftover artifacts whose paths aren't recorded on the row. Including
+    # Sweep the default data dirs as a backstop for peaks files and any
+    # leftover artifacts whose paths aren't recorded on the row. Including
     # peaks_dir here is what prevents data/peaks/{job_id}.json from leaking.
     for d in [settings.uploads_dir, settings.audio_dir, settings.peaks_dir]:
         for f in d.glob(f"{job.id}.*"):
             f.unlink(missing_ok=True)
+
+    # Transcription chunks (split_audio output) use ``_chunk`` suffix —
+    # the dot-glob above misses them. Normal pipelines clean these in
+    # transcribe._cleanup_temp_files, but a crash before that ran can
+    # leave them behind, so sweep on delete as a backstop.
+    for f in settings.audio_dir.glob(f"{job.id}_chunk*"):
+        f.unlink(missing_ok=True)
 
     status_manager.forget_terminal(job_id)
     return {"deleted": True}

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -19,6 +19,7 @@ class Job(Base):
     provider: Mapped[str] = mapped_column(String, nullable=False)
     language: Mapped[str | None] = mapped_column(String, nullable=True)
     audio_duration: Mapped[float | None] = mapped_column(Float, nullable=True)
+    audio_path: Mapped[str | None] = mapped_column(String, nullable=True)
     srt_path: Mapped[str | None] = mapped_column(String, nullable=True)
     youtube_title: Mapped[str | None] = mapped_column(Text, nullable=True)
     youtube_description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/services/peaks.py
+++ b/src/services/peaks.py
@@ -138,32 +138,43 @@ async def _read_cached(cache_path: Path, source_key: str) -> dict | None:
     return cached
 
 
+def _public_payload(stored: dict) -> dict:
+    """Project the on-disk cache payload into the HTTP response shape.
+
+    The ``source`` field is a cache-invalidation invariant (see
+    ``_read_cached``); exposing it in the HTTP response would leak the
+    server-side media path layout to the client.
+    """
+    return {k: v for k, v in stored.items() if k != "source"}
+
+
 async def get_or_generate_peaks(job_id: str, media_path: Path, cache_dir: Path) -> dict:
     """Return cached peaks JSON, generating it on first request.
 
     The cache is keyed by ``job_id`` and stamped with the source media path
     so a change in the underlying file (e.g. switching from the original
     upload to the extracted audio) forces a regeneration instead of
-    returning the previously cached envelope.
+    returning the previously cached envelope. The stamp lives only on disk
+    and is stripped from the returned payload.
     """
     cache_path = cache_dir / f"{job_id}.json"
     source_key = str(media_path)
 
     cached = await _read_cached(cache_path, source_key)
     if cached is not None:
-        return cached
+        return _public_payload(cached)
 
     lock = await _job_lock(job_id)
     async with lock:
         # Re-check inside the lock — another waiter may have produced it.
         cached = await _read_cached(cache_path, source_key)
         if cached is not None:
-            return cached
+            return _public_payload(cached)
 
         logger.info("Generating waveform peaks for job %s from %s", job_id, media_path.name)
         result = await generate_peaks(media_path)
-        result["source"] = source_key
+        to_store = {**result, "source": source_key}
         cache_dir.mkdir(parents=True, exist_ok=True)
         async with aiofiles.open(cache_path, "w") as f:
-            await f.write(json.dumps(result, separators=(",", ":")))
+            await f.write(json.dumps(to_store, separators=(",", ":")))
         return result

--- a/src/services/peaks.py
+++ b/src/services/peaks.py
@@ -114,22 +114,55 @@ async def _job_lock(job_id: str) -> asyncio.Lock:
         return lock
 
 
-async def get_or_generate_peaks(job_id: str, media_path: Path, cache_dir: Path) -> dict:
-    """Return cached peaks JSON, generating it on first request."""
-    cache_path = cache_dir / f"{job_id}.json"
-    if cache_path.exists():
+async def _read_cached(cache_path: Path, source_key: str) -> dict | None:
+    """Return cached peaks JSON only if it was generated from the same source.
+
+    A bare ``{job_id}.json`` cache would happily serve stale peaks if the
+    source path changed between requests — which is exactly what happens
+    when a job's playback source moves from the original upload to the
+    extracted audio. Stamping the cache with the source path and re-checking
+    it on read invalidates the file without needing a separate migration.
+
+    Treats a partial/corrupt write (concurrent writer mid-flush) as a miss
+    so the caller regenerates rather than 500ing.
+    """
+    if not cache_path.exists():
+        return None
+    try:
         async with aiofiles.open(cache_path, "r") as f:
-            return json.loads(await f.read())
+            cached = json.loads(await f.read())
+    except (json.JSONDecodeError, OSError):
+        return None
+    if cached.get("source") != source_key:
+        return None
+    return cached
+
+
+async def get_or_generate_peaks(job_id: str, media_path: Path, cache_dir: Path) -> dict:
+    """Return cached peaks JSON, generating it on first request.
+
+    The cache is keyed by ``job_id`` and stamped with the source media path
+    so a change in the underlying file (e.g. switching from the original
+    upload to the extracted audio) forces a regeneration instead of
+    returning the previously cached envelope.
+    """
+    cache_path = cache_dir / f"{job_id}.json"
+    source_key = str(media_path)
+
+    cached = await _read_cached(cache_path, source_key)
+    if cached is not None:
+        return cached
 
     lock = await _job_lock(job_id)
     async with lock:
         # Re-check inside the lock — another waiter may have produced it.
-        if cache_path.exists():
-            async with aiofiles.open(cache_path, "r") as f:
-                return json.loads(await f.read())
+        cached = await _read_cached(cache_path, source_key)
+        if cached is not None:
+            return cached
 
         logger.info("Generating waveform peaks for job %s from %s", job_id, media_path.name)
         result = await generate_peaks(media_path)
+        result["source"] = source_key
         cache_dir.mkdir(parents=True, exist_ok=True)
         async with aiofiles.open(cache_path, "w") as f:
             await f.write(json.dumps(result, separators=(",", ":")))

--- a/src/services/transcribe.py
+++ b/src/services/transcribe.py
@@ -96,10 +96,22 @@ async def process_transcription(job: Job, session: AsyncSession) -> None:
 
         if transcription_provider == "whisper":
             audio_path = settings.audio_dir / f"{job.id}.wav"
-            duration = await extract_audio(upload_path, audio_path)
+            extractor = extract_audio
         else:
             audio_path = settings.audio_dir / f"{job.id}.mp3"
-            duration = await extract_audio_mp3(upload_path, audio_path)
+            extractor = extract_audio_mp3
+
+        try:
+            duration = await extractor(upload_path, audio_path)
+        except BaseException:
+            # ffmpeg may leave a partial/empty output behind when it fails
+            # or the task is cancelled. Drop it so it doesn't get picked up
+            # later by ``/audio`` (the file is the source of truth once
+            # ``job.audio_path`` is set) or surface as a phantom-success
+            # half-state for jobs whose transcription then fails.
+            if audio_path is not None:
+                audio_path.unlink(missing_ok=True)
+            raise
 
         # Persist the extracted audio path so the editor can play it back
         # with timestamps matching the SRT timeline. MP4/MOV edit lists and

--- a/src/services/transcribe.py
+++ b/src/services/transcribe.py
@@ -101,6 +101,10 @@ async def process_transcription(job: Job, session: AsyncSession) -> None:
             audio_path = settings.audio_dir / f"{job.id}.mp3"
             duration = await extract_audio_mp3(upload_path, audio_path)
 
+        # Persist the extracted audio path so the editor can play it back
+        # with timestamps matching the SRT timeline. MP4/MOV edit lists and
+        # codec delay otherwise produce a drift of up to a few hundred ms.
+        job.audio_path = str(audio_path)
         job.audio_duration = duration
         await session.commit()
 
@@ -266,15 +270,19 @@ async def process_transcription(job: Job, session: AsyncSession) -> None:
         await status_manager.publish(job.id, STATUS_COMPLETED)
 
     finally:
-        # Cleanup temporary files regardless of success/failure
-        _cleanup_temp_files(job.id, audio_path)
+        # Cleanup transcription-only chunk files regardless of success/failure.
+        # The main extracted audio is kept (see job.audio_path).
+        _cleanup_temp_files(audio_path)
 
 
-def _cleanup_temp_files(job_id: str, audio_path: Path | None) -> None:
-    """Remove temporary audio files. MP4 is kept for video embedding."""
+def _cleanup_temp_files(audio_path: Path | None) -> None:
+    """Remove transcription-only intermediate chunks.
+
+    The main extracted audio is intentionally kept and recorded in
+    ``Job.audio_path``: the editor needs to play it back so subtitle
+    timestamps match the audio timeline.
+    """
     if audio_path:
-        audio_path.unlink(missing_ok=True)
-        # Clean up chunks
         for chunk in audio_path.parent.glob(f"{audio_path.stem}_chunk*"):
             chunk.unlink(missing_ok=True)
 

--- a/src/templates/srt_editor.html
+++ b/src/templates/srt_editor.html
@@ -286,7 +286,7 @@ window.srtEditor = function () {
             </select>
             <span x-show="activeSegmentIdx !== null" class="text-xs text-blue-600 font-medium flex-shrink-0" x-text="'#' + (activeSegmentIdx + 1)"></span>
         </div>
-        <audio x-ref="audio" :src="'/api/jobs/{{ job.id }}/media'" preload="metadata"
+        <audio x-ref="audio" :src="'/api/jobs/{{ job.id }}/audio'" preload="metadata"
                @timeupdate="onTimeUpdate()"
                @loadedmetadata="audioDuration = $refs.audio.duration; applyPlaybackRate(); initWaveform()"
                @canplay="_audioCanPlay = true"

--- a/tests/test_peaks.py
+++ b/tests/test_peaks.py
@@ -58,9 +58,11 @@ async def test_get_or_generate_peaks_caches_to_disk(tmp_path):
     cache_file = cache_dir / f"{job_id}.json"
     assert cache_file.exists()
 
-    # Second call must read from cache, not regenerate — corrupt the source
-    # path and confirm we still get the original result.
-    second = await get_or_generate_peaks(job_id, Path("/nonexistent.mp3"), cache_dir)
+    # Second call with the same source must hit the cache. We can't probe a
+    # bogus path here anymore — the source-stamp would invalidate the entry
+    # (see test_get_or_generate_peaks_regenerates_when_source_changes) — so
+    # the cache-hit assertion is on a same-source repeat instead.
+    second = await get_or_generate_peaks(job_id, FIXTURE, cache_dir)
     assert second == first
 
 
@@ -69,11 +71,56 @@ async def test_get_or_generate_peaks_returns_cached_value(tmp_path):
     cache_dir = tmp_path / "peaks"
     cache_dir.mkdir()
     job_id = "preseeded"
-    expected = {"peaks": [0.1, 0.2, 0.3], "duration": 12.5}
+    source = "/nonexistent.mp3"
+    expected = {"peaks": [0.1, 0.2, 0.3], "duration": 12.5, "source": source}
     (cache_dir / f"{job_id}.json").write_text(json.dumps(expected))
 
-    result = await get_or_generate_peaks(job_id, Path("/nonexistent.mp3"), cache_dir)
+    result = await get_or_generate_peaks(job_id, Path(source), cache_dir)
     assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_get_or_generate_peaks_regenerates_when_source_changes(tmp_path):
+    """A cache stamped with a different source must be invalidated.
+
+    This is the contract that keeps issue #73's waveform aligned with the
+    SRT timeline: switching the playback source from the original upload
+    to the extracted audio must force a regeneration instead of returning
+    the previously cached envelope.
+    """
+    cache_dir = tmp_path / "peaks"
+    cache_dir.mkdir()
+    job_id = "stale"
+    stale = {"peaks": [0.0], "duration": 1.0, "source": "/old/source.mp3"}
+    (cache_dir / f"{job_id}.json").write_text(json.dumps(stale))
+
+    fake_result = {"peaks": [0.9], "duration": 9.0}
+    with patch("src.services.peaks.generate_peaks", new=AsyncMock(return_value=fake_result)) as mock_gen:
+        result = await get_or_generate_peaks(job_id, Path("/new/source.mp3"), cache_dir)
+
+    mock_gen.assert_awaited_once()
+    assert result["peaks"] == [0.9]
+    assert result["source"] == "/new/source.mp3"
+
+
+@pytest.mark.asyncio
+async def test_get_or_generate_peaks_treats_corrupt_cache_as_miss(tmp_path):
+    """A partial / corrupt cache write (concurrent writer) regenerates cleanly.
+
+    Treating ``json.JSONDecodeError`` as a cache miss keeps a transient mid-
+    flush window from surfacing as a 500 to the client.
+    """
+    cache_dir = tmp_path / "peaks"
+    cache_dir.mkdir()
+    job_id = "corrupt"
+    (cache_dir / f"{job_id}.json").write_text("{not valid json")
+
+    fake_result = {"peaks": [0.5], "duration": 5.0}
+    with patch("src.services.peaks.generate_peaks", new=AsyncMock(return_value=fake_result)) as mock_gen:
+        result = await get_or_generate_peaks(job_id, Path("/some/source.mp3"), cache_dir)
+
+    mock_gen.assert_awaited_once()
+    assert result["peaks"] == [0.5]
 
 
 # ---- ffmpeg-mocked tests: exercise the bucketing/cache/locking logic on CI

--- a/tests/test_peaks.py
+++ b/tests/test_peaks.py
@@ -206,7 +206,9 @@ async def test_get_or_generate_peaks_writes_compact_cache(tmp_path):
     # Compact separators keep the JSON small for transfer.
     assert ", " not in text
     assert ": " not in text
-    assert json.loads(text) == fake_result
+    # On-disk cache also carries the source stamp used for invalidation —
+    # the HTTP-facing payload strips it, but persistence keeps it.
+    assert json.loads(text) == {**fake_result, "source": "/fake.mp3"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_peaks.py
+++ b/tests/test_peaks.py
@@ -72,11 +72,12 @@ async def test_get_or_generate_peaks_returns_cached_value(tmp_path):
     cache_dir.mkdir()
     job_id = "preseeded"
     source = "/nonexistent.mp3"
-    expected = {"peaks": [0.1, 0.2, 0.3], "duration": 12.5, "source": source}
-    (cache_dir / f"{job_id}.json").write_text(json.dumps(expected))
+    stored = {"peaks": [0.1, 0.2, 0.3], "duration": 12.5, "source": source}
+    (cache_dir / f"{job_id}.json").write_text(json.dumps(stored))
 
     result = await get_or_generate_peaks(job_id, Path(source), cache_dir)
-    assert result == expected
+    assert result == {"peaks": [0.1, 0.2, 0.3], "duration": 12.5}
+    assert "source" not in result
 
 
 @pytest.mark.asyncio
@@ -100,7 +101,11 @@ async def test_get_or_generate_peaks_regenerates_when_source_changes(tmp_path):
 
     mock_gen.assert_awaited_once()
     assert result["peaks"] == [0.9]
-    assert result["source"] == "/new/source.mp3"
+    assert "source" not in result
+
+    # The on-disk cache, in contrast, keeps the source stamp for invalidation.
+    on_disk = json.loads((cache_dir / f"{job_id}.json").read_text())
+    assert on_disk["source"] == "/new/source.mp3"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -299,6 +299,52 @@ async def test_refine_failure_populates_error_detail(monkeypatch):
     assert "upstream refine failure" in detail["raw_message"]
 
 
+@pytest.mark.asyncio
+async def test_extraction_failure_removes_partial_audio(monkeypatch):
+    """ffmpeg crashing mid-write must not leave a partial file at audio_path.
+
+    The persisted ``audio_path`` is the source of truth for ``/audio`` and
+    ``/peaks``; if extraction half-wrote a file and then the call raised,
+    the cleanup must drop that partial output before the exception
+    propagates. Otherwise the editor would stream gibberish later.
+    """
+    from src.models import Job
+    from src.services import transcribe as transcribe_mod
+
+    job = Job(id="test-extract-fail", filename="x.wav", file_size=1, provider="whisper")
+
+    async def fake_get_credential(_session, _provider):
+        return "fake-key"
+
+    async def fake_extract(_in_path, out_path):
+        # Simulate ffmpeg writing a partial output then bailing.
+        out_path.write_bytes(b"partial-junk")
+        raise RuntimeError("ffmpeg command failed: simulated crash")
+
+    monkeypatch.setattr(transcribe_mod, "_get_credential", fake_get_credential)
+    monkeypatch.setattr(transcribe_mod, "extract_audio", fake_extract)
+
+    upload_dir = transcribe_mod.settings.uploads_dir
+    audio_dir = transcribe_mod.settings.audio_dir
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    (upload_dir / f"{job.id}.wav").write_bytes(b"")
+    expected_audio_path = audio_dir / f"{job.id}.wav"
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+
+    try:
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            await transcribe_mod.process_transcription(job, session)
+        assert not expected_audio_path.exists(), "partial audio_path must be removed when extraction fails"
+        assert job.audio_path is None, "audio_path should not be persisted on extraction failure"
+    finally:
+        (upload_dir / f"{job.id}.wav").unlink(missing_ok=True)
+        expected_audio_path.unlink(missing_ok=True)
+
+
 # -- Whisper prompt tests --
 
 

--- a/tests/test_segment_operations.py
+++ b/tests/test_segment_operations.py
@@ -126,7 +126,7 @@ async def test_get_segments_includes_glossary(make_client):
 
 
 # ---------------------------------------------------------------------------
-# Media endpoint
+# Media / audio endpoints
 # ---------------------------------------------------------------------------
 
 
@@ -140,6 +140,106 @@ async def test_media_endpoint_returns_file(make_client):
         # test.mp3 upload file exists (4 bytes), should serve it
         assert resp.status_code == 200
         assert "audio" in resp.headers.get("content-type", "")
+    finally:
+        await cleanup_job(make_client, job_id)
+
+
+async def _set_audio_path(job_id: str, audio_path) -> None:
+    from sqlalchemy import select
+
+    from src.database import async_session
+    from src.models import Job
+
+    async with async_session() as session:
+        result = await session.execute(select(Job).where(Job.id == job_id))
+        job = result.scalar_one()
+        job.audio_path = str(audio_path)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_audio_endpoint_uses_audio_path_when_present(make_client):
+    """When job.audio_path points to an extracted file, /audio serves that file.
+
+    This is the fix for #73: the editor must play the same audio whose timeline
+    the SRT segments are anchored to, not the original upload that may drift
+    due to MP4 edit lists or codec delay.
+    """
+    from src.config import settings
+
+    job_id = await create_test_job(make_client)
+    audio_path = settings.audio_dir / f"{job_id}.wav"
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+    extracted_payload = b"EXTRACTED_AUDIO_BYTES"
+    audio_path.write_bytes(extracted_payload)
+    try:
+        await _set_audio_path(job_id, audio_path)
+        async with make_client() as c:
+            resp = await c.get(f"/api/jobs/{job_id}/audio")
+        assert resp.status_code == 200
+        assert resp.content == extracted_payload
+        assert resp.headers.get("content-type") == "audio/wav"
+    finally:
+        await cleanup_job(make_client, job_id)
+
+
+@pytest.mark.asyncio
+async def test_audio_endpoint_falls_back_to_upload_for_legacy_jobs(make_client):
+    """Jobs created before the audio_path column was added still play back.
+
+    audio_path is NULL → endpoint falls back to the original upload, preserving
+    backward compatibility for any job in the DB before this migration ran.
+    """
+    job_id = await create_test_job(make_client)
+    try:
+        async with make_client() as c:
+            resp = await c.get(f"/api/jobs/{job_id}/audio")
+        assert resp.status_code == 200
+        assert "audio" in resp.headers.get("content-type", "")
+    finally:
+        await cleanup_job(make_client, job_id)
+
+
+@pytest.mark.asyncio
+async def test_audio_endpoint_404_when_both_sources_missing(make_client):
+    """Neither audio_path file nor uploads file → 404, not crash."""
+    from src.config import settings
+
+    job_id = await create_test_job(make_client)
+    try:
+        await _set_audio_path(job_id, "/nonexistent/path.wav")
+        for f in settings.uploads_dir.glob(f"{job_id}.*"):
+            f.unlink(missing_ok=True)
+        async with make_client() as c:
+            resp = await c.get(f"/api/jobs/{job_id}/audio")
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "MEDIA_NOT_FOUND"
+    finally:
+        await cleanup_job(make_client, job_id)
+
+
+@pytest.mark.asyncio
+async def test_media_endpoint_serves_original_when_audio_path_set(make_client):
+    """`/media` keeps serving the upload even when audio_path is populated.
+
+    The two endpoints have separate responsibilities: /media is for the
+    original media file (download, future video preview), /audio is for the
+    timestamp-aligned playback. Conflating them was the bug that gate1 caught.
+    """
+    from src.config import settings
+
+    job_id = await create_test_job(make_client)
+    audio_path = settings.audio_dir / f"{job_id}.wav"
+    audio_path.parent.mkdir(parents=True, exist_ok=True)
+    audio_path.write_bytes(b"EXTRACTED")
+    try:
+        await _set_audio_path(job_id, audio_path)
+        async with make_client() as c:
+            resp = await c.get(f"/api/jobs/{job_id}/media")
+        assert resp.status_code == 200
+        # Upload file is `test.mp3` (4 bytes "fake") — not the extracted bytes.
+        assert resp.content != b"EXTRACTED"
+        assert resp.content == b"fake"
     finally:
         await cleanup_job(make_client, job_id)
 

--- a/tests/test_segment_operations.py
+++ b/tests/test_segment_operations.py
@@ -219,6 +219,41 @@ async def test_audio_endpoint_404_when_both_sources_missing(make_client):
 
 
 @pytest.mark.asyncio
+async def test_delete_job_sweeps_chunk_files(make_client):
+    """Chunk files (``{job_id}_chunkNNN.{ext}``) must be cleaned on delete.
+
+    ``split_audio`` produces these as siblings of the main extracted audio.
+    They have an underscore separator so the dot-glob ``{job_id}.*`` misses
+    them; ``delete_job`` needs an explicit chunk sweep as a backstop for
+    pipelines that crashed before transcribe.py's own cleanup ran.
+    """
+    from src.config import settings
+
+    job_id = await create_test_job(make_client)
+    settings.audio_dir.mkdir(parents=True, exist_ok=True)
+    main_audio = settings.audio_dir / f"{job_id}.wav"
+    chunk_a = settings.audio_dir / f"{job_id}_chunk000.wav"
+    chunk_b = settings.audio_dir / f"{job_id}_chunk001.wav"
+    main_audio.write_bytes(b"AUDIO")
+    chunk_a.write_bytes(b"CHUNK0")
+    chunk_b.write_bytes(b"CHUNK1")
+    try:
+        await _set_audio_path(job_id, main_audio)
+        async with make_client() as c:
+            resp = await c.delete(f"/api/jobs/{job_id}")
+        assert resp.status_code == 200
+        assert not main_audio.exists()
+        assert not chunk_a.exists()
+        assert not chunk_b.exists()
+    finally:
+        # cleanup_job is idempotent — calling it after a successful delete
+        # just returns 404, which the helper tolerates.
+        await cleanup_job(make_client, job_id)
+        for stray in (main_audio, chunk_a, chunk_b):
+            stray.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
 async def test_media_endpoint_serves_original_when_audio_path_set(make_client):
     """`/media` keeps serving the upload even when audio_path is populated.
 


### PR DESCRIPTION
Closes #73

## Summary
- Editor played the original upload while subtitle timestamps were anchored to the ffmpeg-extracted audio — MP4 edit lists / codec delay caused up to a few hundred ms of drift
- Persists the extracted audio path on `Job.audio_path` and serves it via a new `GET /api/jobs/{id}/audio` endpoint so the editor playhead matches the SRT timeline
- Keeps `/media` serving the original upload (responsibility separation for download / future video preview)
- `/peaks` switched to the same source as `/audio` and the cache is stamped with the source path so a switch from original to extracted forces regeneration

## Implementation notes
- `Job.audio_path` nullable column + Alembic migration `d4f8a2b6c1e9` (legacy jobs with NULL fall back to the upload via `_resolve_playback_path`)
- `_resolve_playback_path` / `_find_upload_path` helpers shared between `/audio` and `/peaks` to guarantee a single source of truth; helpers return existing paths only so callers can drop redundant `.exists()` guards
- `transcribe._cleanup_temp_files` no longer deletes the main extracted audio (only `_chunk*` intermediates); transcription persists `job.audio_path` immediately after extraction succeeds
- `peaks.get_or_generate_peaks` stores `source` in the cached JSON and treats partial-write `JSONDecodeError`/`OSError` as a cache miss to dodge concurrent-writer 500s
- `delete_job` now sweeps `settings.peaks_dir` (was leaking `{job_id}.json`) and explicitly unlinks `audio_path` to mirror the `srt_path` cleanup pattern

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CTO lens; edge cases addressed before continue)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/73-feat-fix-srt.gate1.md
- ~/.claude/cache/gh-issue-driven/73-feat-fix-srt.gate2.md

## Test plan
- [x] 4 new tests added in `tests/test_segment_operations.py` (audio_path used / legacy fallback / `/media` unchanged / 404 when both sources missing)
- [x] ruff check + ruff format — clean
- [x] `python -m py_compile` on all modified files — ok
- [x] Direct httpx integration script — all 4 scenarios PASS (synthetic job + audio_path set/unset)
- [x] Manual curl against running uvicorn — `/audio` returns extracted bytes with `audio/wav`, `/media` returns upload, both return structured 404 when no source
- [x] Jinja-rendered editor page (`/srt/<id>`) shows `<audio :src="/api/jobs/<id>/audio">` (template change applied)
- [ ] CI pytest run (pre-existing local hang from #74/#75 prevented local run)

## Follow-ups (out of scope for this PR)
- Storage retention policy for persisted extracted audio (220MB/hr WAV, 28MB/hr MP3) — separate issue recommended
- Unit test for `_read_cached` source-stamp invalidation in `tests/test_peaks.py`
- Local pytest hang (lifespan `validate_model` external API call) — tracked under #74/#75

🤖 Generated via /gh-issue-driven:ship
