### PR TITLE
fix: batch #74, #75 — explicit timeouts on OpenAI and Gemini API calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11"
 license = {text = "MIT"}
 dependencies = [
     "fastapi>=0.115.0,<1.0.0",
-    "httpx>=0.27.0",
+    "httpx>=0.27.0,<1.0.0",
     "uvicorn[standard]>=0.34.0,<1.0.0",
     "jinja2>=3.1.0,<4.0.0",
     "python-multipart>=0.0.18,<1.0.0",
@@ -27,7 +27,6 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
     "pytest-playwright>=0.6.0",
-    "httpx>=0.27.0",
     "ruff>=0.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 license = {text = "MIT"}
 dependencies = [
     "fastapi>=0.115.0,<1.0.0",
+    "httpx>=0.27.0",
     "uvicorn[standard]>=0.34.0,<1.0.0",
     "jinja2>=3.1.0,<4.0.0",
     "python-multipart>=0.0.18,<1.0.0",

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -195,15 +195,27 @@ async def test_key(provider: str, session: AsyncSession = Depends(get_session)):
 
     try:
         if provider == "openai":
-            import openai
+            import httpx
 
-            client = openai.AsyncOpenAI(api_key=api_key)
+            from src.services.utils import (
+                OPENAI_CONNECT_TIMEOUT_SEC,
+                SHORT_RPC_TIMEOUT_SEC,
+                create_openai_compatible_client,
+            )
+
+            client = create_openai_compatible_client(
+                "openai",
+                api_key,
+                timeout=httpx.Timeout(SHORT_RPC_TIMEOUT_SEC, connect=OPENAI_CONNECT_TIMEOUT_SEC),
+            )
             await client.models.list()
         elif provider == "google":
             from google import genai
 
+            from src.services.utils import SHORT_RPC_TIMEOUT_SEC, call_gemini_with_timeout
+
             client = genai.Client(api_key=api_key)
-            client.models.list()
+            await call_gemini_with_timeout(client.models.list, timeout=SHORT_RPC_TIMEOUT_SEC)
         return {"valid": True}
     except Exception as e:
         return {"valid": False, "error": str(e)}

--- a/src/services/catchphrase.py
+++ b/src/services/catchphrase.py
@@ -2,7 +2,12 @@
 
 import logging
 
-from src.services.utils import create_openai_compatible_client, extract_gemini_tokens, parse_json_response
+from src.services.utils import (
+    call_gemini_with_timeout,
+    create_openai_compatible_client,
+    extract_gemini_tokens,
+    parse_json_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,12 +67,10 @@ async def _generate_openai_compat(
 
 
 async def _generate_gemini(prompt: str, api_key: str, model: str) -> tuple[list[dict], int, int]:
-    import asyncio
-
     from google import genai
 
     client = genai.Client(api_key=api_key)
-    response = await asyncio.to_thread(
+    response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,
         contents=prompt,

--- a/src/services/gemini.py
+++ b/src/services/gemini.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from google import genai
 from google.genai.types import GenerateContentConfig
 
-from src.services.utils import call_gemini_with_timeout, extract_gemini_tokens, parse_json_response
+from src.services.utils import (
+    SHORT_RPC_TIMEOUT_SEC,
+    call_gemini_with_timeout,
+    extract_gemini_tokens,
+    parse_json_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +60,9 @@ Example: [{{"start": 0.0, "end": 2.5, "text": "Hello, welcome."}}]{glossary_hint
     segments = parse_json_response(response.text, context="Gemini transcription")
     input_tokens, output_tokens = extract_gemini_tokens(response)
 
-    # Clean up uploaded file (best-effort; timeout or API error must not fail the job)
+    # Best-effort cleanup; a stuck delete must not stall job teardown.
     try:
-        await call_gemini_with_timeout(client.files.delete, name=uploaded.name)
+        await call_gemini_with_timeout(client.files.delete, name=uploaded.name, timeout=SHORT_RPC_TIMEOUT_SEC)
     except Exception:
         logger.warning("Failed to delete uploaded file: %s", uploaded.name)
 

--- a/src/services/gemini.py
+++ b/src/services/gemini.py
@@ -1,15 +1,12 @@
-import asyncio
 import logging
 from pathlib import Path
 
 from google import genai
 from google.genai.types import GenerateContentConfig
 
-from src.services.utils import extract_gemini_tokens, parse_json_response
+from src.services.utils import call_gemini_with_timeout, extract_gemini_tokens, parse_json_response
 
 logger = logging.getLogger(__name__)
-
-GEMINI_TIMEOUT_SEC = 600  # 10 minutes
 
 
 async def transcribe_with_gemini(
@@ -25,7 +22,7 @@ async def transcribe_with_gemini(
     """
     client = genai.Client(api_key=api_key)
 
-    uploaded = await asyncio.to_thread(client.files.upload, file=str(audio_path))
+    uploaded = await call_gemini_with_timeout(client.files.upload, file=str(audio_path))
 
     lang_hint = f" The audio is in {language}." if language else ""
     glossary_hint = ""
@@ -45,25 +42,22 @@ Return ONLY a JSON array, no other text or markdown. Each element must have:
 Keep segments at natural sentence boundaries, roughly 1-10 seconds each.
 Example: [{{"start": 0.0, "end": 2.5, "text": "Hello, welcome."}}]{glossary_hint}"""
 
-    response = await asyncio.wait_for(
-        asyncio.to_thread(
-            client.models.generate_content,
-            model=model,
-            contents=[uploaded, prompt],
-            config=GenerateContentConfig(
-                max_output_tokens=65536,
-                response_mime_type="application/json",
-            ),
+    response = await call_gemini_with_timeout(
+        client.models.generate_content,
+        model=model,
+        contents=[uploaded, prompt],
+        config=GenerateContentConfig(
+            max_output_tokens=65536,
+            response_mime_type="application/json",
         ),
-        timeout=GEMINI_TIMEOUT_SEC,
     )
 
     segments = parse_json_response(response.text, context="Gemini transcription")
     input_tokens, output_tokens = extract_gemini_tokens(response)
 
-    # Clean up uploaded file
+    # Clean up uploaded file (best-effort; timeout or API error must not fail the job)
     try:
-        await asyncio.to_thread(client.files.delete, name=uploaded.name)
+        await call_gemini_with_timeout(client.files.delete, name=uploaded.name)
     except Exception:
         logger.warning("Failed to delete uploaded file: %s", uploaded.name)
 

--- a/src/services/gemini.py
+++ b/src/services/gemini.py
@@ -26,9 +26,27 @@ async def transcribe_with_gemini(
     Returns (segments, input_tokens, output_tokens).
     """
     client = genai.Client(api_key=api_key)
-
     uploaded = await call_gemini_with_timeout(client.files.upload, file=str(audio_path))
 
+    try:
+        return await _transcribe_uploaded(client, uploaded, model, language, glossary)
+    finally:
+        # Best-effort cleanup — runs even if transcription raises/times out so
+        # uploaded files don't pile up on Gemini's side. A stuck delete must not
+        # stall job teardown, hence the short budget.
+        try:
+            await call_gemini_with_timeout(client.files.delete, name=uploaded.name, timeout=SHORT_RPC_TIMEOUT_SEC)
+        except Exception:
+            logger.warning("Failed to delete uploaded file: %s", uploaded.name)
+
+
+async def _transcribe_uploaded(
+    client,
+    uploaded,
+    model: str,
+    language: str | None,
+    glossary: str,
+) -> tuple[list[dict], int, int]:
     lang_hint = f" The audio is in {language}." if language else ""
     glossary_hint = ""
     if glossary.strip():
@@ -59,11 +77,4 @@ Example: [{{"start": 0.0, "end": 2.5, "text": "Hello, welcome."}}]{glossary_hint
 
     segments = parse_json_response(response.text, context="Gemini transcription")
     input_tokens, output_tokens = extract_gemini_tokens(response)
-
-    # Best-effort cleanup; a stuck delete must not stall job teardown.
-    try:
-        await call_gemini_with_timeout(client.files.delete, name=uploaded.name, timeout=SHORT_RPC_TIMEOUT_SEC)
-    except Exception:
-        logger.warning("Failed to delete uploaded file: %s", uploaded.name)
-
     return segments, input_tokens, output_tokens

--- a/src/services/gemini.py
+++ b/src/services/gemini.py
@@ -36,6 +36,9 @@ async def transcribe_with_gemini(
         # stall job teardown, hence the short budget.
         try:
             await call_gemini_with_timeout(client.files.delete, name=uploaded.name, timeout=SHORT_RPC_TIMEOUT_SEC)
+        except TimeoutError:
+            # call_gemini_with_timeout() already logs timeout warnings.
+            pass
         except Exception:
             logger.warning("Failed to delete uploaded file: %s", uploaded.name)
 

--- a/src/services/metadata.py
+++ b/src/services/metadata.py
@@ -222,7 +222,6 @@ async def _generate_gemini(prompt: str, api_key: str, model: str) -> tuple[dict,
     from google import genai
 
     client = genai.Client(api_key=api_key)
-    # Run synchronous Gemini client in thread pool with explicit timeout
     response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,

--- a/src/services/metadata.py
+++ b/src/services/metadata.py
@@ -1,5 +1,10 @@
 from src.constants import get_provider_name
-from src.services.utils import create_openai_compatible_client, extract_gemini_tokens, parse_json_response
+from src.services.utils import (
+    call_gemini_with_timeout,
+    create_openai_compatible_client,
+    extract_gemini_tokens,
+    parse_json_response,
+)
 
 METADATA_SYSTEM_PROMPT = (
     "You are an expert at generating YouTube video metadata. "
@@ -179,17 +184,15 @@ async def optimize_meta_prompt(
         )
         return response.choices[0].message.content or current_prompt
     else:
-        import asyncio
-
         from google import genai
 
         client = genai.Client(api_key=api_key)
-        response = await asyncio.to_thread(
+        response = await call_gemini_with_timeout(
             client.models.generate_content,
             model=model,
             contents=prompt,
         )
-        return response.text.strip() or current_prompt
+        return (response.text or "").strip() or current_prompt
 
 
 async def _generate_openai_compat(
@@ -216,13 +219,11 @@ async def _generate_openai_compat(
 
 
 async def _generate_gemini(prompt: str, api_key: str, model: str) -> tuple[dict, int, int]:
-    import asyncio
-
     from google import genai
 
     client = genai.Client(api_key=api_key)
-    # Run synchronous Gemini client in thread pool to avoid blocking event loop
-    response = await asyncio.to_thread(
+    # Run synchronous Gemini client in thread pool with explicit timeout
+    response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,
         contents=f"{METADATA_SYSTEM_PROMPT}\n\n{prompt}",

--- a/src/services/model_validator.py
+++ b/src/services/model_validator.py
@@ -21,7 +21,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.constants import get_provider_name
 from src.errors import model_not_available
-from src.services.utils import create_openai_compatible_client, fetch_ollama_models
+from src.services.utils import (
+    SHORT_RPC_TIMEOUT_SEC,
+    call_gemini_with_timeout,
+    create_openai_compatible_client,
+    fetch_ollama_models,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +127,7 @@ async def _check_gemini(model: str, credential: str) -> None:
         return client.models.get(model=full_name)
 
     try:
-        await asyncio.to_thread(_retrieve)
+        await call_gemini_with_timeout(_retrieve, timeout=SHORT_RPC_TIMEOUT_SEC)
     except Exception as e:
         # google-genai does not expose structured 404 — fall back to string match.
         msg = str(e)

--- a/src/services/quiz.py
+++ b/src/services/quiz.py
@@ -2,7 +2,12 @@
 
 import logging
 
-from src.services.utils import create_openai_compatible_client, extract_gemini_tokens, parse_json_response
+from src.services.utils import (
+    call_gemini_with_timeout,
+    create_openai_compatible_client,
+    extract_gemini_tokens,
+    parse_json_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,12 +67,10 @@ async def _generate_openai_compat(
 
 
 async def _generate_gemini(prompt: str, api_key: str, model: str) -> tuple[list[dict], int, int]:
-    import asyncio
-
     from google import genai
 
     client = genai.Client(api_key=api_key)
-    response = await asyncio.to_thread(
+    response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,
         contents=prompt,

--- a/src/services/refine.py
+++ b/src/services/refine.py
@@ -3,7 +3,12 @@
 import json
 import logging
 
-from src.services.utils import create_openai_compatible_client, extract_gemini_tokens, parse_json_response
+from src.services.utils import (
+    call_gemini_with_timeout,
+    create_openai_compatible_client,
+    extract_gemini_tokens,
+    parse_json_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -195,13 +200,11 @@ async def _refine_openai_compat(
 
 
 async def _refine_gemini(prompt: str, api_key: str, model: str) -> tuple[list[dict], int, int]:
-    import asyncio
-
     from google import genai
     from google.genai.types import GenerateContentConfig
 
     client = genai.Client(api_key=api_key)
-    response = await asyncio.to_thread(
+    response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,
         contents=f"{REFINE_SYSTEM_PROMPT}\n\n{prompt}",
@@ -347,13 +350,11 @@ async def _verify_openai_compat(
 
 
 async def _verify_gemini(prompt: str, api_key: str, model: str) -> tuple[list[dict], int, int]:
-    import asyncio
-
     from google import genai
     from google.genai.types import GenerateContentConfig
 
     client = genai.Client(api_key=api_key)
-    response = await asyncio.to_thread(
+    response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,
         contents=f"{VERIFY_SYSTEM_PROMPT}\n\n{prompt}",
@@ -466,13 +467,11 @@ async def _suggest_openai_compat(
 
 
 async def _suggest_gemini(prompt: str, api_key: str, model: str) -> tuple[str, str, int, int]:
-    import asyncio
-
     from google import genai
     from google.genai.types import GenerateContentConfig
 
     client = genai.Client(api_key=api_key)
-    response = await asyncio.to_thread(
+    response = await call_gemini_with_timeout(
         client.models.generate_content,
         model=model,
         contents=f"{SUGGEST_SYSTEM_PROMPT}\n\n{prompt}",

--- a/src/services/utils.py
+++ b/src/services/utils.py
@@ -189,11 +189,25 @@ async def call_gemini_with_timeout(
     ``asyncio.to_thread``. Without ``asyncio.wait_for`` the thread can wait
     indefinitely if the API hangs (.claude/rules/async-first.md). Use this
     helper for every Gemini call site so the timeout policy stays uniform.
+
+    Note: ``asyncio.wait_for`` cancels the awaiting coroutine, not the
+    underlying worker thread — a hung SDK call keeps occupying its
+    ``asyncio.to_thread`` slot until the network layer finally errors out.
+    The warning log gives operational visibility into that condition so
+    repeated timeouts can be diagnosed before they pile up.
     """
-    return await asyncio.wait_for(
-        asyncio.to_thread(fn, *args, **kwargs),
-        timeout=timeout,
-    )
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(fn, *args, **kwargs),
+            timeout=timeout,
+        )
+    except TimeoutError:
+        logger.warning(
+            "Gemini call timed out after %.1fs (fn=%s) — worker thread may still be running",
+            timeout,
+            getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn))),
+        )
+        raise
 
 
 def extract_gemini_tokens(response) -> tuple[int, int]:

--- a/src/services/utils.py
+++ b/src/services/utils.py
@@ -1,7 +1,21 @@
+import asyncio
 import json
 import logging
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import httpx
 
 logger = logging.getLogger(__name__)
+
+# Timeout policy for external LLM calls (CLAUDE.md / .claude/rules/async-first.md).
+# Long enough for Whisper / Gemini to process multi-minute audio, with a short
+# connect deadline so a dead endpoint fails fast.
+OPENAI_TIMEOUT_SEC: float = 600.0
+OPENAI_CONNECT_TIMEOUT_SEC: float = 10.0
+GEMINI_TIMEOUT_SEC: float = 600.0
+
+T = TypeVar("T")
 
 
 def strip_markdown_fence(text: str) -> str:
@@ -100,8 +114,6 @@ async def fetch_ollama_models(base_url: str, timeout: float = 5.0) -> list[str] 
         - `None` when the request itself failed (network error, non-200,
           non-JSON body). Callers must distinguish this from an empty list.
     """
-    import httpx
-
     url = _resolve_ollama_url(base_url.rstrip("/"))
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -135,16 +147,49 @@ def _resolve_ollama_url(url: str) -> str:
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
-def create_openai_compatible_client(provider: str, credential: str):
-    """Create an AsyncOpenAI client for OpenAI or Ollama (OpenAI-compatible)."""
+def create_openai_compatible_client(
+    provider: str,
+    credential: str,
+    *,
+    timeout: httpx.Timeout | float | None = None,
+):
+    """Create an AsyncOpenAI client for OpenAI or Ollama (OpenAI-compatible).
+
+    Sets an explicit httpx timeout so calls cannot hang indefinitely
+    (.claude/rules/async-first.md). Callers may override via the ``timeout``
+    kwarg; ``None`` selects the default ``OPENAI_TIMEOUT_SEC`` /
+    ``OPENAI_CONNECT_TIMEOUT_SEC`` policy.
+    """
     import openai
+
+    if timeout is None:
+        timeout = httpx.Timeout(OPENAI_TIMEOUT_SEC, connect=OPENAI_CONNECT_TIMEOUT_SEC)
 
     if provider == "ollama":
         base = _resolve_ollama_url(credential.rstrip("/"))
         if base.endswith("/v1"):
             base = base[:-3]
-        return openai.AsyncOpenAI(base_url=f"{base}/v1", api_key="ollama")
-    return openai.AsyncOpenAI(api_key=credential)
+        return openai.AsyncOpenAI(base_url=f"{base}/v1", api_key="ollama", timeout=timeout)
+    return openai.AsyncOpenAI(api_key=credential, timeout=timeout)
+
+
+async def call_gemini_with_timeout(
+    fn: Callable[..., T],
+    *args: Any,
+    timeout: float = GEMINI_TIMEOUT_SEC,
+    **kwargs: Any,
+) -> T:
+    """Run a synchronous Gemini SDK call in a worker thread with an asyncio timeout.
+
+    The Gemini Python SDK is blocking, so the project wraps every call in
+    ``asyncio.to_thread``. Without ``asyncio.wait_for`` the thread can wait
+    indefinitely if the API hangs (.claude/rules/async-first.md). Use this
+    helper for every Gemini call site so the timeout policy stays uniform.
+    """
+    return await asyncio.wait_for(
+        asyncio.to_thread(fn, *args, **kwargs),
+        timeout=timeout,
+    )
 
 
 def extract_gemini_tokens(response) -> tuple[int, int]:

--- a/src/services/utils.py
+++ b/src/services/utils.py
@@ -14,6 +14,10 @@ logger = logging.getLogger(__name__)
 OPENAI_TIMEOUT_SEC: float = 600.0
 OPENAI_CONNECT_TIMEOUT_SEC: float = 10.0
 GEMINI_TIMEOUT_SEC: float = 600.0
+# Short budget for cheap RPCs (API-key validation, file deletion). The full
+# 600s budget would let a hung lightweight call block job teardown for 10
+# minutes — exactly the failure mode the timeout is meant to prevent.
+SHORT_RPC_TIMEOUT_SEC: float = 30.0
 
 T = TypeVar("T")
 

--- a/src/services/whisper.py
+++ b/src/services/whisper.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import openai
+from src.services.utils import create_openai_compatible_client
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ async def transcribe_with_whisper(
 
     Returns list of segments: [{"start": float, "end": float, "text": str}, ...]
     """
-    client = openai.AsyncOpenAI(api_key=api_key)
+    client = create_openai_compatible_client("openai", api_key)
 
     kwargs: dict[str, Any] = {
         "model": "whisper-1",

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,101 @@
+"""Tests for explicit timeouts on external LLM calls.
+
+Covers .claude/rules/async-first.md — "All external API calls must have
+explicit timeouts" — verified for both providers:
+
+- OpenAI: explicit httpx.Timeout on the AsyncOpenAI / openai-compatible client
+- Gemini: asyncio.wait_for around to_thread via call_gemini_with_timeout
+"""
+
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from src.services.utils import (
+    GEMINI_TIMEOUT_SEC,
+    OPENAI_CONNECT_TIMEOUT_SEC,
+    OPENAI_TIMEOUT_SEC,
+    call_gemini_with_timeout,
+    create_openai_compatible_client,
+)
+
+
+class TestTimeoutConstants:
+    def test_openai_timeout_matches_gemini(self):
+        # Whisper / Gemini both process multi-minute audio; aligning timeouts
+        # keeps the two providers operationally indistinguishable from a
+        # user-perceived-hang perspective.
+        assert OPENAI_TIMEOUT_SEC == GEMINI_TIMEOUT_SEC == 600.0
+
+    def test_openai_connect_timeout_is_short(self):
+        # Connect must fail fast; only the total budget is generous.
+        assert OPENAI_CONNECT_TIMEOUT_SEC == 10.0
+
+
+class TestCreateOpenAICompatibleClientTimeout:
+    def test_openai_default_timeout(self):
+        client = create_openai_compatible_client("openai", "sk-fake")
+        assert isinstance(client.timeout, httpx.Timeout)
+        assert client.timeout.read == OPENAI_TIMEOUT_SEC
+        assert client.timeout.connect == OPENAI_CONNECT_TIMEOUT_SEC
+
+    def test_ollama_default_timeout(self):
+        client = create_openai_compatible_client("ollama", "http://localhost:11434")
+        assert isinstance(client.timeout, httpx.Timeout)
+        assert client.timeout.read == OPENAI_TIMEOUT_SEC
+        assert client.timeout.connect == OPENAI_CONNECT_TIMEOUT_SEC
+
+    def test_custom_timeout_override(self):
+        custom = httpx.Timeout(5.0, connect=1.0)
+        client = create_openai_compatible_client("openai", "sk-fake", timeout=custom)
+        assert isinstance(client.timeout, httpx.Timeout)
+        assert client.timeout.read == 5.0
+        assert client.timeout.connect == 1.0
+
+
+class TestCallGeminiWithTimeout:
+    @pytest.mark.asyncio
+    async def test_returns_value_when_fn_completes(self):
+        def quick():
+            return "ok"
+
+        result = await call_gemini_with_timeout(quick)
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_forwards_args_and_kwargs(self):
+        def add(a, b, *, c=0):
+            return a + b + c
+
+        result = await call_gemini_with_timeout(add, 1, 2, c=3)
+        assert result == 6
+
+    @pytest.mark.asyncio
+    async def test_raises_timeout_when_fn_hangs(self):
+        def hang():
+            # Real Gemini hang would be much longer; use a tiny budget so the
+            # test stays under a second. Sleep slightly longer than timeout to
+            # give wait_for a chance to fire.
+            time.sleep(0.5)
+            return "should not reach"
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await call_gemini_with_timeout(hang, timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_propagates_fn_exceptions(self):
+        def boom():
+            raise RuntimeError("from gemini")
+
+        with pytest.raises(RuntimeError, match="from gemini"):
+            await call_gemini_with_timeout(boom)
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_gemini_timeout_sec(self):
+        # Inspect the helper's default timeout without actually waiting it out.
+        import inspect
+
+        sig = inspect.signature(call_gemini_with_timeout)
+        assert sig.parameters["timeout"].default == GEMINI_TIMEOUT_SEC

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -93,9 +93,14 @@ class TestCallGeminiWithTimeout:
             await call_gemini_with_timeout(boom)
 
     @pytest.mark.asyncio
-    async def test_default_timeout_is_gemini_timeout_sec(self):
-        # Inspect the helper's default timeout without actually waiting it out.
-        import inspect
+    async def test_default_timeout_is_gemini_timeout_sec(self, monkeypatch):
+        captured: dict = {}
+        real_wait_for = asyncio.wait_for
 
-        sig = inspect.signature(call_gemini_with_timeout)
-        assert sig.parameters["timeout"].default == GEMINI_TIMEOUT_SEC
+        async def spy(coro, timeout):
+            captured["timeout"] = timeout
+            return await real_wait_for(coro, timeout)
+
+        monkeypatch.setattr("src.services.utils.asyncio.wait_for", spy)
+        await call_gemini_with_timeout(lambda: "ok")
+        assert captured["timeout"] == GEMINI_TIMEOUT_SEC


### PR DESCRIPTION
Closes #74
Closes #75

## Summary
- Add explicit timeouts to every OpenAI and Gemini external API call (CLAUDE.md / .claude/rules/async-first.md compliance)
- New helper `call_gemini_with_timeout()` consolidates the `asyncio.wait_for(asyncio.to_thread(...))` pattern at 7+ call sites
- New constants `OPENAI_TIMEOUT_SEC=600`, `OPENAI_CONNECT_TIMEOUT_SEC=10`, `SHORT_RPC_TIMEOUT_SEC=30`; `GEMINI_TIMEOUT_SEC` moved from `gemini.py` to `utils.py`
- Extends `create_openai_compatible_client()` with an optional `timeout` kwarg, used by `/api/settings/.../test_key` for a 30s validation budget
- Side fix: `src/api/settings.py:206` was calling `client.models.list()` synchronously inside an async handler (event-loop blocking) — now wrapped in `call_gemini_with_timeout` properly

## Implementation notes
- All 7 Gemini call sites (`catchphrase.py`, `quiz.py`, `refine.py` x3, `metadata.py` x2, `gemini.py`) migrated from inline `asyncio.wait_for(asyncio.to_thread(...))` boilerplate to the new `call_gemini_with_timeout(fn, *args, **kwargs)` helper
- `gemini.transcribe_with_gemini` uses `SHORT_RPC_TIMEOUT_SEC` (30s) for the `files.delete` cleanup so a stuck delete cannot stall job teardown
- `whisper.transcribe_with_whisper` now routes through `create_openai_compatible_client("openai", ...)` for consistency with the new timeout policy
- 8 `genai.Client(api_key=...)` constructions remain inline — intentionally not consolidated (scope discipline; no current need beyond cosmetic dedup)
- New `tests/test_timeout.py` — 10 unit tests covering constants policy, OpenAI client timeout (default + ollama + custom override), and the Gemini helper (return value / args / timeout firing / exception propagation / default-value behavioral spy)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- review provider: code-review

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/74-75-batch_explicit-timeouts.gate2.md`

🤖 Generated via `/gh-issue-driven:ship`
